### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+jobs:
+  build:
+    name: Run MATLAB checks and tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          products: >
+            Mapping_Toolbox
+            Image_Processing_Toolbox
+      - name: Run checks and tests
+        uses: matlab-actions/run-build@v2
+        with:
+          tasks: check test

--- a/buildfile.m
+++ b/buildfile.m
@@ -1,12 +1,20 @@
 function plan = buildfile
-    plan = buildplan;
+    plan = buildplan(localfunctions);
     
     plan("check") = matlab.buildtool.tasks.CodeIssuesTask("toolbox");
-    plan("test") = matlab.buildtool.tasks.TestTask("tests");
     plan("package") = matlab.buildtool.Task( ...
         Description = "Package toolbox", ...
         Dependencies = ["check" "test"], ...
         Actions = @packageToolbox);
 
     plan.DefaultTasks = ["check" "test" "package"];
+end
+
+function testTask(~)
+    oldpath = addpath(genpath("toolbox"));
+    finalize = onCleanup(@()(path(oldpath)));
+
+    results = runtests("IncludeSubfolders",true);
+    disp(results);
+    assertSuccess(results);
 end


### PR DESCRIPTION
Resolves #2

`.github/workflow/ci.yaml` uses matlab-actions/setup-matlab@v2 to install the latest release of MATLAB on the runner and then runs the tasks in `buildfile.m` using matlab-actions/run-build@v2. Note that the tests require the Mapping Toolbox and Image Processing Toolbox which we install using the `products` property in the setup-matlab task. Any additional products that are needed by the tests in the future must be added here. The names of the products can be found at https://raw.githubusercontent.com/mathworks-ref-arch/matlab-dockerfile/main/mpm-input-files/R2024a/mpm_input_r2024a.txt

`buildfile.m` now uses `buildplan(localfunctions)` to create the "test" task rather than using the default `TestTask`. This allows us to include `toolbox/` on the path and ensure that the tests can see the toolbox code.