### PR TITLE
Compile libtopotoolbox

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,8 @@ jobs:
           products: >
             Mapping_Toolbox
             Image_Processing_Toolbox
+            MATLAB_Coder
       - name: Run checks and tests
         uses: matlab-actions/run-build@v2
         with:
-          tasks: check test
+          tasks: compile check test

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ codegen/
 
 # API keys
 *.apikey
+
+# CMake build directory
+build/
+
+# Internal folder for compiled MEX files
+toolbox/internal/mex/

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(
+  mxtopotoolbox
+  VERSION 0.0.1
+  LANGUAGES C
+)
+
+include(FindMatlab)
+
+include(FetchContent)
+FetchContent_Declare(
+  topotoolbox
+  GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
+  GIT_TAG 2024-W36
+)
+FetchContent_MakeAvailable(topotoolbox)
+
+matlab_add_mex(
+  NAME tt_has_topotoolbox
+  MODULE
+  SRC tt_has_topotoolbox.c
+  R2018a
+  LINK_TO topotoolbox
+)
+
+install(
+  TARGETS tt_has_topotoolbox
+  DESTINATION "."
+  COMPONENT Runtime
+)

--- a/bindings/tt_has_topotoolbox.c
+++ b/bindings/tt_has_topotoolbox.c
@@ -1,0 +1,32 @@
+/*
+
+tt_has_topotoolbox.c
+
+Returns true
+
+This is used to test the compilation and linking procedure for
+libtopotoolbox
+*/
+
+#include "mex.h"
+#include "topotoolbox.h"
+
+
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
+{
+    // INPUTS: -
+    // OUTPUTS: flag
+    if (nrhs != 0) {
+        mexErrMsgIdAndTxt("tt3:tt_has_topotoolbox:nrhs","Zero inputs required");
+    }
+    if (nlhs != 1) {
+        mexErrMsgIdAndTxt("tt3:tt_has_topotoolbox:nlhs","One output required");
+    }
+
+    const mwSize dims[1] = {1};
+    plhs[0] = mxCreateLogicalArray(1,dims);
+    mxLogical *flag = mxGetLogicals(plhs[0]);
+    mxAssert(flag,"Flag pointer is null");
+
+    *flag = has_topotoolbox();
+}

--- a/buildfile.m
+++ b/buildfile.m
@@ -18,3 +18,20 @@ function testTask(~)
     disp(results);
     assertSuccess(results);
 end
+
+function compileTask(~)
+    %% Path to MATLAB provided cmake
+    cmake = fullfile(matlabroot, 'bin', computer('arch'),'cmake','bin','cmake');
+    % The windows version has a blank in the program folder name
+    % (C:/Program Files), thus we use additional double quotes.
+    cmake = ['"' cmake '"'];
+
+    if system(strcat(cmake," --version")) ~= 0
+        disp("CMake is not provided by MATLAB. MATLAB Coder must be installed.");
+        return;
+    end
+    %% Run cmake
+    system(strcat(cmake," -S bindings/ -B build -DCMAKE_BUILD_TYPE=Release"));
+    system(strcat(cmake," --build build --config Release"));
+    system(strcat(cmake," --install build --prefix toolbox/internal/mex --component Runtime"));
+end

--- a/tests/testHasLibTopoToolbox.m
+++ b/tests/testHasLibTopoToolbox.m
@@ -1,0 +1,7 @@
+classdef testHasLibTopoToolbox < matlab.unittest.TestCase
+    methods(Test)
+        function check_haslibtopotoolbox(testCase)
+            verifyReturnsTrue(testCase,@haslibtopotoolbox)
+        end
+    end
+end

--- a/toolbox/internal/haslibtopotoolbox.m
+++ b/toolbox/internal/haslibtopotoolbox.m
@@ -1,0 +1,9 @@
+function out = haslibtopotoolbox
+%HASLIBTOPOTOOLBOX Test if the libtopotoolbox MEX bindings are available
+mexx = exist(['mex/tt_has_topotoolbox.' mexext],'file');
+if mexx == 3
+    out = tt_has_topotoolbox;
+else
+    out = false;
+end
+end


### PR DESCRIPTION
buildfile.m adds `compileTask`, which finds the MATLAB-provided CMake and compiles the libtopotoolbox bindings. If the MATLAB-provided CMake does not exist, it prints a message and returns.

bindings/ contains the MEX C files that implement the bindings as well as the CMakeLists.txt that sets up the build system.

bindings/tt_has_topotoolbox.c is a MEX binding for the has_topotoolbox function from libtopotoolbox that always returns 1.

toolbox/internal/haslibtopotoolbox.m is a MATLAB function that wraps the tt_has_topotoolbox MEX function. If it finds the MEX function it runs it and returns the true output. If it does not find the MEX function, it returns false.

The compile build task will build everything in a build/ directory in the root of the repository. This can be deleted once buildtool is finished.

.gitignore is updated to ignore both the build/ directory and the topotoolbox/internal/mex directory that the MEX files get installed to.

tests/testHasLibTopoToolbox.m adds a test that haslibtopotoolbox returns true.

.github/workflows/ci.yaml adds the compile task to the CI configuration. It also adds MATLAB Coder, which ensures that CMake is available.

# Discussion

Resolves #8 

I am open to the idea of moving the `bindings/` directory. We could put the MEX C files in the directories that are most appropriate for their functionality (e.g. `tt_fillsinks.c` could be in a subfolder of `toolbox/@GRIDobj/private`).

At the moment the MEX files are not included in the packaged toolbox. It should be a matter of adding the `toolbox/internal/mex/` directory to the list of toolbox files.