### PR TITLE
Print errors and warnings in the check task

### DIFF
--- a/buildfile.m
+++ b/buildfile.m
@@ -20,13 +20,21 @@ function checkTask(~)
     if ~isempty(errors)
         disp("Errors");
         disp("======")
-        disp(errors);
+        for i = 1:height(errors)
+            fprintf("%s:%d\n",errors{i,"FullFilename"}, ...
+                errors{i,"LineStart"});
+            fprintf("  %s\n",errors{i,"Description"});
+        end
     end
 
     if ~isempty(warnings)
         disp("Warnings");
         disp("========")
-        disp(warnings);
+        for i = 1:height(warnings)
+            fprintf("%s:%d\n",warnings{i,"FullFilename"}, ...
+                warnings{i,"LineStart"});
+            fprintf("  %s\n",warnings{i,"Description"});
+        end
     end
 
     assert(isempty(errors));

--- a/buildfile.m
+++ b/buildfile.m
@@ -12,8 +12,10 @@ end
 function checkTask(~)
     issues = codeIssues("toolbox");
 
-    errors = issues.Issues(issues.Issues.Severity=="error",:);
-    warnings = issues.Issues(issues.Issues.Severity=="warning",:);
+    errors = issues.Issues(issues.Issues.Severity=="error", ...
+        ["FullFilename", "LineStart", "Description"]);
+    warnings = issues.Issues(issues.Issues.Severity=="warning", ...
+        ["FullFilename", "LineStart", "Description"]);
 
     if ~isempty(errors)
         disp("Errors");

--- a/buildfile.m
+++ b/buildfile.m
@@ -1,13 +1,33 @@
 function plan = buildfile
     plan = buildplan(localfunctions);
     
-    plan("check") = matlab.buildtool.tasks.CodeIssuesTask("toolbox");
     plan("package") = matlab.buildtool.Task( ...
         Description = "Package toolbox", ...
         Dependencies = ["check" "test"], ...
         Actions = @packageToolbox);
 
     plan.DefaultTasks = ["check" "test" "package"];
+end
+
+function checkTask(~)
+    issues = codeIssues("toolbox");
+
+    errors = issues.Issues(issues.Issues.Severity=="error",:);
+    warnings = issues.Issues(issues.Issues.Severity=="warning",:);
+
+    if ~isempty(errors)
+        disp("Errors");
+        disp("======")
+        disp(errors);
+    end
+
+    if ~isempty(warnings)
+        disp("Warnings");
+        disp("========")
+        disp(warnings);
+    end
+
+    assert(isempty(errors));
 end
 
 function testTask(~)


### PR DESCRIPTION
buildfile.m adds a local checkTask function which runs `codeIssues` and prints out any errors and warnings. It fails the task if there are any errors.

This is largely based on this article from Andy Campbell:

https://blogs.mathworks.com/developer/2023/03/15/static-analysis-code-checking-and-linting-with-codeissues/