### PR TITLE
Implement snapshot tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: true
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tests/data"]
+	path = tests/snapshots
+	url = https://github.com/TopoToolbox/test_data
+	branch = main

--- a/tests/testSnapshot.m
+++ b/tests/testSnapshot.m
@@ -1,0 +1,108 @@
+classdef testSnapshot < matlab.unittest.TestCase
+    % testSnapshot Snapshot testing using topotoolbox3 as a reference
+    % The data for the snapshot tests are stored in the
+    % TopoToolbox/test_data repository. This repository is added as a
+    % submodule to topotoolbox3 at the path tests/data.
+    %
+    % The basic strategy for these tests:
+    %
+    % 1. The snapshot tests are run just like a normal test for
+    %    topotoolbox3.
+    % 2. If there is no data for a given test in the tests/data directory,
+    %    the test will create it.
+    % 3. If the appropriate data does exist in the tests/data directory,
+    %    they will be compared against the results computed here. The test
+    %    will fail if the saved version and the computed version do not
+    %    match according to the test. Be careful when adding new tests
+    %    requiring floating point comparison.
+    % 4. Snapshotting of results must currently be done manually. If you
+    %    want to save the results of a test run:
+    %    - Commit the new data to the /submodule/, not to topoboolbox3
+    %    - Push the commit to your fork of TopoToolbox/test_data and make a
+    %    pull request.
+    %    - Once the pull request is merged, pull the new changes into the
+    %    submodule and commit the changed submodule to the
+    %    topotoolbox3 repository.
+    % 5. If a change to the results is known and expected, delete the
+    %    appropriate snapshot from the tests/data repository and create the
+    %    new one following the procedure outlined above.
+
+    properties
+        dem
+    end
+
+    properties (ClassSetupParameter)
+        dataset
+    end
+
+    methods (TestParameterDefinition,Static)
+        function dataset = findDatasets()
+            % Find all the existing snapshot datasets
+            available_datasets = [{},struct2table(dir("snapshots/*/dem.tif")).folder];
+            if ~isempty(available_datasets)
+                dataset = available_datasets;
+            else
+                error("No snapshots found.");
+            end
+        end
+    end
+
+    methods (TestClassSetup)
+        % Shared setup for the entire test class
+        function read_data(testCase,dataset)
+            data_file = fullfile(dataset,"dem.tif");
+            testCase.dem = GRIDobj(data_file);
+        end
+    end
+
+    methods (TestMethodSetup)
+        % Setup for each test
+    end
+
+    methods (Test)
+        % Test methods
+        function fillsinks(testCase,dataset)
+            demf = testCase.dem.fillsinks();
+
+            result_file = fullfile(dataset,"fillsinks.tif");
+
+            if ~isfile(result_file)
+                % Write the result to the directory
+                demf.GRIDobj2geotiff(result_file);
+            else
+                demf_result = GRIDobj(result_file);
+                testCase.verifyEqual(demf_result.Z,demf.Z);
+            end
+        end
+
+        function identifyflats(testCase, dataset)
+            demf = testCase.dem.fillsinks();
+            [FLATS, SILLS, CLOSED] = demf.identifyflats();
+
+            flats_file = fullfile(dataset,"identifyflats_flats.tif");
+            sills_file = fullfile(dataset,"identifyflats_sills.tif");
+            closed_file = fullfile(dataset,"identifyflats_closed.tif");
+
+            if ~isfile(flats_file)
+                FLATS.GRIDobj2geotiff(flats_file);
+            else
+                flats_result = GRIDobj(flats_file);
+                testCase.verifyEqual(logical(flats_result.Z),FLATS.Z);
+            end
+
+            if ~isfile(sills_file)
+                SILLS.GRIDobj2geotiff(sills_file);
+            else
+                sills_result = GRIDobj(sills_file);
+                testCase.verifyEqual(logical(sills_result.Z),SILLS.Z);
+            end
+
+            if ~isfile(closed_file)
+                CLOSED.GRIDobj2geotiff(closed_file);
+            else
+                closed_result = GRIDobj(closed_file);
+                testCase.verifyEqual(logical(closed_result.Z),CLOSED.Z);
+            end
+        end
+    end
+end


### PR DESCRIPTION
Snapshot testing verifies that changes that we make to our code do not unexpectedly change the results. It compares snapshots of the output from previously run tests to the output from the new code, and the tests fail if the new output does not equal the old one. If we do need make changes that will change the output of our functions, we first will update the snapshots with the new output and then make the changes. The procedure for doing this is outlined in a comment at the top of testSnapshots.m. At the moment, all of this updating must be done manually.

This code implements snapshot tests for topotoolbox3 and also uses topotoolbox3 to generate snapshots that can be used elseswhere in our ecosystem. Since topotoolbox3 already includes implementations of the algorithms that we are adding to libtopotoolbox and elsewhere, it makes sense to generate snapshots from the existing topotoolbox3 code. In cases such as `excesstopography`, where we know we want to replace the MATLAB implementation with a new libtopotoolbox implementation that provides different output, we can update the snapshot repository with outputs from those algorithms when we want to make those changes to topotoolbox3.

Snapshots are stored in the [TopoToolbox/test_data repository](https://github.com/TopoToolbox/test_data), which is added as a git submodule (`tests/snapshots`) here. The `.gitmodules` file contains the metadata that git needs to track that repository.

Each dataset gets its own directory within that repository, and the test harness finds all of the datasets and runs the snapshot tests on them.

The snapshot tests currently run `fillsinks` and `identifyflats` with their default arguments. `identifyflats` is applied to the filled DEM so that it is more likely to discover flat regions. These are the first two steps of the default flow routing algorithm implemented in libtopotoolbox, so they can easily be turned into tests for libtopotoolbox.

It is important to note that snapshot tests can be very strict: small changes in the output will cause the tests to fail even if those changes are not scientifically meaningful. It is possible to make the tests less stringent by comparing output within certain tolerances, for instance, or by verifying properties that the output should share with the snapshot other than exact equality.

That said, I mostly want snapshots for [testing libtopotoolbox](https://github.com/TopoToolbox/libtopotoolbox/issues/96) against the existing MATLAB implementations (see
https://github.com/TopoToolbox/libtopotoolbox/issues/122 for example). While I could run and upload these snapshots on my own, keeping the tests under version control in topotoolbox3 tracks the provenance of the snapshots without needing to duplicate metadata, and including them in the automated tests ensures that the snapshots do indeed reflect the current and expected behavior of TopoToolbox.

If it does become burdensome to update the snapshots after making small changes to the MATLAB implementations, we can exclude these tests from the checks that run for pull requests and merges on GitHub.