### PR TITLE
Implement fillsinks MEX function and use it within GRIDobj.fillsinks

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -12,7 +12,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG main
+  GIT_TAG 2024-W43
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -12,7 +12,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 2024-W36
+  GIT_TAG main
 )
 FetchContent_MakeAvailable(topotoolbox)
 
@@ -24,8 +24,16 @@ matlab_add_mex(
   LINK_TO topotoolbox
 )
 
+matlab_add_mex(
+  NAME tt_fillsinks
+  MODULE
+  SRC tt_fillsinks.c
+  R2018a
+  LINK_TO topotoolbox
+)
+
 install(
-  TARGETS tt_has_topotoolbox
+  TARGETS tt_has_topotoolbox tt_fillsinks
   DESTINATION "."
   COMPONENT Runtime
 )

--- a/bindings/tt_fillsinks.c
+++ b/bindings/tt_fillsinks.c
@@ -1,0 +1,45 @@
+/*
+
+tt_fillsinks.c
+
+*/
+
+#include "matrix.h"
+#include "mex.h"
+#include "topotoolbox.h"
+
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+  // INPUTS: DEM, bc
+  // OUTPUTS: DEMF
+  if (nrhs != 2) {
+    mexErrMsgIdAndTxt("tt3:tt_fillsinks:nrhs", "Two inputs required");
+  }
+  if (nlhs != 1) {
+    mexErrMsgIdAndTxt("tt3:tt_fillsinks:nlhs", "One output required");
+  }
+
+  const mxArray *demArray = prhs[0];
+  float *dem = mxGetSingles(demArray);
+
+  const mxArray *bcArray = prhs[1];
+  uint8_t *bc = mxGetUint8s(prhs[1]);
+
+  ptrdiff_t dims[2];
+  dims[0] = mxGetM(demArray);
+  dims[1] = mxGetN(demArray);
+
+  // Null pointer checks are not needed because out-of-memory errors
+  // will terminate the MEX function.
+  plhs[0] = mxCreateNumericMatrix(dims[0], dims[1], mxSINGLE_CLASS, mxREAL);
+  float *out = mxGetSingles(plhs[0]);
+
+  // Allocate the intermediate array for the FIFO queue used by the hybrid
+  // algorithm
+  mxArray *queueArray =
+      mxCreateNumericMatrix(dims[0], dims[1], mxINT64_CLASS, mxREAL);
+  ptrdiff_t *queue = (ptrdiff_t *)mxGetInt64s(queueArray);
+
+  fillsinks_hybrid(out, queue, dem, bc, dims);
+
+  mxDestroyArray(queueArray);
+}

--- a/toolbox/@GRIDobj/fillsinks.m
+++ b/toolbox/@GRIDobj/fillsinks.m
@@ -79,14 +79,19 @@ Inan      = isnan(dem);
 % set nans to -inf
 dem(Inan) = -inf;
 
-if nargin == 1
-    % fill depressions using imreconstruct with an 8-neighborhood
+if nargin == 1 && haslibtopotoolbox
+    % Using libtopotoolbox
+    bc = ones(size(dem), 'uint8');
+    bc(2:end-1, 2:end-1) = 0;
+    bc(Inan) = 1;
+    demfs = tt_fillsinks(dem, bc);
+elseif  nargin == 1
+    % Fall back to imreconstruct without libtopotoolbox
     marker     = -dem;
     II         = false(size(dem));
     II(2:end-1,2:end-1) = true;
     marker(II & ~Inan) = -inf;
-    demfs      = -imreconstruct(marker,-dem,8);
-    
+    demfs = -imreconstruct(marker,-dem,8);
 elseif nargin==2 && md
     
     % create mask


### PR DESCRIPTION
Resolves #19

This commit adds `bindings/tt_fillsinks.c`, which implements a MEX function that calls libtopotoolbox's `fillsinks`. It allocates memory for the output and intermediate arrays within the MEX function and passes pointers to those arrays to libtopotoolbox. Allocation failures will terminate the MEX function and return control to MATLAB.

bindings/CMakeLists.txt adds the tt_fillsinks MEX target to the compilation pipeline. This currently must be done manually for each MEX file we want to compile.

toolbox/@GRIDobj/fillsinks.m is updated to use `tt_fillsinks` when passed a single argument. We could probably use libtopotoolbox code for the maximum depth and minima imposition as well, but the current `fillsinks` function always does the preprocessing required for the full sink filling algorithm before calling our `reconstruct` function. `reconstruct` is not exported by libtopotoolbox at the moment, though it could be.

The existing snapshot tests should catch any problems with `tt_fillsinks`, so no additional tests are added.