### PR TITLE
Change submodule URL to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/snapshots"]
 	path = tests/snapshots
-	url = git@github.com:TopoToolbox/snapshot_data
+	url = https://github.com/TopoToolbox/snapshot_data


### PR DESCRIPTION
This is a minor change to ensure that the submodule is usable without SSH authentication by default. One can locally change the remote url of the submodule or configure git to substitute SSH for the https url if necessary.