### PR TITLE
Implement binding for libtopotoolbox identifyflats

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -12,7 +12,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG main
+  GIT_TAG 2024-W44
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -12,7 +12,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 2024-W43
+  GIT_TAG main
 )
 FetchContent_MakeAvailable(topotoolbox)
 
@@ -32,8 +32,16 @@ matlab_add_mex(
   LINK_TO topotoolbox
 )
 
+matlab_add_mex(
+  NAME tt_identifyflats
+  MODULE
+  SRC tt_identifyflats.c
+  R2018a
+  LINK_TO topotoolbox
+)
+
 install(
-  TARGETS tt_has_topotoolbox tt_fillsinks
+  TARGETS tt_has_topotoolbox tt_fillsinks tt_identifyflats
   DESTINATION "."
   COMPONENT Runtime
 )

--- a/bindings/tt_identifyflats.c
+++ b/bindings/tt_identifyflats.c
@@ -1,0 +1,23 @@
+#include "mex.h"
+#include "topotoolbox.h"
+
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+
+  if (nrhs != 1) {
+    mexErrMsgIdAndTxt("tt3:tt_identifyflats:nrhs", "One input required");
+  }
+  if (nlhs != 1) {
+    mexErrMsgIdAndTxt("tt3:tt_identifyflats:nrls", "One output required");
+  }
+
+  const mxArray *demArray = prhs[0];
+  float *dem = mxGetSingles(demArray);
+  ptrdiff_t dims[2];
+  dims[0] = mxGetM(demArray);
+  dims[1] = mxGetN(demArray);
+
+  plhs[0] = mxCreateNumericMatrix(dims[0], dims[1], mxINT32_CLASS, mxREAL);
+  int32_t *out = mxGetInt32s(plhs[0]);
+
+  identifyflats(out, dem, dims);
+}

--- a/toolbox/@GRIDobj/identifyflats.m
+++ b/toolbox/@GRIDobj/identifyflats.m
@@ -40,38 +40,49 @@ function varargout = identifyflats(DEM)
 % Author: Wolfgang Schwanghart (w.schwanghart[at]geo.uni-potsdam.de)
 % Date: 26. April, 2018
 
-
 narginchk(1,1)
 dem = DEM.Z;
 
-
-% handle NaNs
+% identify NaNs
+% libtopotoolbox's implementation does not need the NaNs removed from
+% the DEM, so we remove them below after deciding whether we will use
+% libtopotoolbox
 log_nans = isnan(dem);
 if any(log_nans(:))
     flag_nans = true;
-    dem(log_nans) = -inf;
 else
     flag_nans = false;
 end
-nhood = ones(3);
 
-
-% identify flats
-% flats: logical matrix with true where cells don't have lower neighbors
-if flag_nans
-    flats = imerode(dem,nhood) == dem & ~log_nans;
+if haslibtopotoolbox
+    % Use libtopotoolbox's identifyflats
+    % bitget(iflats,1) == 1 for flats
+    % bitget(iflats,2) == 1 for sills
+    % bitget(iflats,4) == 1 for pre-sills
+    % 2024-10-07: closed pixels are not yet identified by
+    % libtopotoolbox
+    iflats = tt_identifyflats(dem);
+    flats = bitget(iflats,1) == 1;
 else
-    flats = imerode(dem,nhood) == dem;
+    % Fallback to the Image Processing Toolbox
+    dem(log_nans) = -inf;
+
+    if flag_nans
+        flats = imerode(dem,ones(3)) == dem & ~log_nans;
+    else
+        flats = imerode(dem,ones(3)) == dem;
+    end
+
+    % remove flats at the border
+    flats(1:end,[1 end]) = false;
+    flats([1 end], 1:end) = false;
+
+    if flag_nans
+        % remove flat pixels bordering to nans
+        flats(imdilate(log_nans,ones(3))) = false;
+    end
 end
 
-% remove flats at the border
-flats(1:end,[1 end])  = false;
-flats([1 end],1:end)  = false;
-
-if flag_nans
-    % remove flat pixels bordering to nans
-    flats(imdilate(log_nans,ones(3))) = false;
-end
 
 % prepare output
 varargout{1} = DEM;
@@ -79,15 +90,19 @@ varargout{1}.Z = flats;
 varargout{1}.name = 'flats';
 
 % identify sills
-if nargout >= 2   
-    % find sills and set marker
-    Imr = -inf(size(dem));
-    Imr(flats) = dem(flats);
-    Imr = (imdilate(Imr,ones(3)) == dem) & ~flats;
-    
-    if flag_nans
-        Imr(log_nans) = false;
+if nargout >= 2
+    if haslibtopotoolbox
+        Imr = bitget(iflats,2) == 1;
+    else
+        Imr = -inf(size(dem));
+        Imr(flats) = dem(flats);
+        Imr = (imdilate(Imr,ones(3)) == dem) & ~flats;
+
+        if flag_nans
+            Imr(log_nans) = false;
+        end
     end
+
     % prepare output
     varargout{2} = DEM;
     varargout{2}.Z = Imr;
@@ -96,6 +111,11 @@ end
 
 % identify interior basins
 if nargout >= 3
+    if haslibtopotoolbox
+        % libtopotoolbox doesn't yet compute interior basins
+        % so we need to process the NaNs if we haven't already
+        dem(log_nans) = -inf;
+    end
     varargout{3} = DEM;
     varargout{3}.Z = imregionalmin(dem);
     
@@ -109,4 +129,7 @@ if nargout >= 3
     varargout{3}.name = 'closed basins';
 end
 
+
+
+end
 


### PR DESCRIPTION
Resolves #20

Adds a new MEX file, tt_identifyflats in bindings/ and the appropriate CMakeLists.txt declaration. This depends on recent changes to libtopotoolbox's `identifyflats` that handle NaNs correctly. The version of libtopotoolbox using in bindings/CMakeLists.txt is set to `main` for testing, but it should be fixed at `2024-W44` once that release is made. This PR should not be merged before that release is available.

@GRIDobj/identifyflats.m is updated to use tt_identifyflats for identifying flats and sills. Closed basins are not handled by libtopotoolbox's identifyflats at the moment, so they are processed as they were before, using `imregionalmin`. If libtopotoolbox is not available the implementation falls back to the previous Image Processing Toolbox functions.