### PR TITLE
Bump snapshots submodule to v1.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Run MATLAB checks and tests
     env:
-      snapshot_version: v1.3.0
+      snapshot_version: v1.4.0
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
This is the version that includes the new acv snapshots.