### PR TITLE
Remove trailing backslash from path in tt2path

### DIFF
--- a/toolbox/tt2path.m
+++ b/toolbox/tt2path.m
@@ -18,7 +18,7 @@ p = mfilename('fullpath');
 f = fileparts(p);
 oldfolder = cd(f);
 
-cd("..\")
+cd("..")
 addpath(genpath('toolbox'))
 
 rmpath(['toolbox' filesep 'help'])


### PR DESCRIPTION
The trailing backslash causes an error on Linux, and I believe that using `".."` without the backslash should still work on Windows. Let me know if that is not the case.