### PR TITLE
Convert snapshot tests to benchmarks

### DIFF
--- a/buildfile.m
+++ b/buildfile.m
@@ -6,6 +6,8 @@ function plan = buildfile
         Dependencies = ["check" "test"], ...
         Actions = @packageToolbox);
 
+    plan("benchmark").Dependencies = "compile";
+
     plan.DefaultTasks = ["check" "test" "package"];
 end
 
@@ -64,4 +66,12 @@ function compileTask(~)
     system(strcat(cmake," -S bindings/ -B build -DCMAKE_BUILD_TYPE=Release"));
     system(strcat(cmake," --build build --config Release"));
     system(strcat(cmake," --install build --prefix toolbox/internal/mex --component Runtime"));
+end
+
+function benchmarkTask(~)
+    oldpath = addpath(genpath("toolbox"));
+    finalize = onCleanup(@()(path(oldpath)));
+
+    results = runperf("tests/testSnapshot.m");
+    disp(sampleSummary(results));
 end

--- a/tests/testSnapshot.m
+++ b/tests/testSnapshot.m
@@ -78,6 +78,10 @@ classdef testSnapshot < matlab.unittest.TestCase
         dataset
     end
 
+    properties (TestParameter)
+        uselibtt = {false, true};
+    end
+
     methods (TestParameterDefinition,Static)
         function dataset = findDatasets()
             % Find all the existing snapshot datasets
@@ -104,12 +108,12 @@ classdef testSnapshot < matlab.unittest.TestCase
 
     methods (Test)
         % Test methods
-        function fillsinks(testCase,dataset)
-            demf = testCase.dem.fillsinks();
+        function fillsinks(testCase,dataset, uselibtt)
+            demf = testCase.dem.fillsinks(uselibtt=uselibtt);
 
             result_file = fullfile(dataset,"fillsinks.tif");
 
-            if ~isfile(result_file)
+            if ~isfile(result_file) && ~uselibtt
                 % Write the result to the directory
                 demf.GRIDobj2geotiff(result_file);
             else
@@ -118,29 +122,29 @@ classdef testSnapshot < matlab.unittest.TestCase
             end
         end
 
-        function identifyflats(testCase, dataset)
-            demf = testCase.dem.fillsinks();
+        function identifyflats(testCase, dataset, uselibtt)
+            demf = testCase.dem.fillsinks(uselibtt=uselibtt);
             [FLATS, SILLS, CLOSED] = demf.identifyflats();
 
             flats_file = fullfile(dataset,"identifyflats_flats.tif");
             sills_file = fullfile(dataset,"identifyflats_sills.tif");
             closed_file = fullfile(dataset,"identifyflats_closed.tif");
 
-            if ~isfile(flats_file)
+            if ~isfile(flats_file) && ~uselibtt
                 FLATS.GRIDobj2geotiff(flats_file);
             else
                 flats_result = GRIDobj(flats_file);
                 testCase.verifyEqual(logical(flats_result.Z),FLATS.Z);
             end
 
-            if ~isfile(sills_file)
+            if ~isfile(sills_file) && ~uselibtt
                 SILLS.GRIDobj2geotiff(sills_file);
             else
                 sills_result = GRIDobj(sills_file);
                 testCase.verifyEqual(logical(sills_result.Z),SILLS.Z);
             end
 
-            if ~isfile(closed_file)
+            if ~isfile(closed_file) && ~uselibtt
                 CLOSED.GRIDobj2geotiff(closed_file);
             else
                 closed_result = GRIDobj(closed_file);
@@ -162,17 +166,17 @@ classdef testSnapshot < matlab.unittest.TestCase
             end
         end
 
-        function auxtopo(testCase, dataset)
+        function auxtopo(testCase, dataset, uselibtt)
             D = testCase.dem;
             D.Z = single(createAuxiliaryTopo(testCase.dem, ...
                 'preprocess', 'carve', ...
-                'uselibtt',true, ...
+                'uselibtt',uselibtt, ...
                 'verbose', false, ...
                 'internaldrainage',false));
 
             result_file = fullfile(dataset,"auxtopo.tif");
 
-            if ~isfile(result_file)
+            if ~isfile(result_file) && ~uselibtt
                 D.GRIDobj2geotiff(result_file);
             else
                 D_result = GRIDobj(result_file);

--- a/tests/testSnapshot.m
+++ b/tests/testSnapshot.m
@@ -85,7 +85,7 @@ classdef testSnapshot < matlab.unittest.TestCase
     methods (TestParameterDefinition,Static)
         function dataset = findDatasets()
             % Find all the existing snapshot datasets
-            available_datasets = [{},struct2table(dir("snapshots/data/*/dem.tif")).folder];
+            [~,available_datasets,~] = fileparts([{},struct2table(dir("snapshots/data/*/dem.tif")).folder]);
             if ~isempty(available_datasets)
                 dataset = available_datasets;
             else
@@ -97,7 +97,7 @@ classdef testSnapshot < matlab.unittest.TestCase
     methods (TestClassSetup)
         % Shared setup for the entire test class
         function read_data(testCase,dataset)
-            data_file = fullfile(dataset,"dem.tif");
+            data_file = fullfile("snapshots/data/",dataset,"dem.tif");
             testCase.dem = GRIDobj(data_file);
         end
     end
@@ -111,7 +111,7 @@ classdef testSnapshot < matlab.unittest.TestCase
         function fillsinks(testCase,dataset, uselibtt)
             demf = testCase.dem.fillsinks(uselibtt=uselibtt);
 
-            result_file = fullfile(dataset,"fillsinks.tif");
+            result_file = fullfile("snapshots/data/",dataset,"fillsinks.tif");
 
             if ~isfile(result_file) && ~uselibtt
                 % Write the result to the directory
@@ -126,9 +126,9 @@ classdef testSnapshot < matlab.unittest.TestCase
             demf = testCase.dem.fillsinks(uselibtt=uselibtt);
             [FLATS, SILLS, CLOSED] = demf.identifyflats();
 
-            flats_file = fullfile(dataset,"identifyflats_flats.tif");
-            sills_file = fullfile(dataset,"identifyflats_sills.tif");
-            closed_file = fullfile(dataset,"identifyflats_closed.tif");
+            flats_file = fullfile("snapshots/data/",dataset,"identifyflats_flats.tif");
+            sills_file = fullfile("snapshots/data/",dataset,"identifyflats_sills.tif");
+            closed_file = fullfile("snapshots/data/",dataset,"identifyflats_closed.tif");
 
             if ~isfile(flats_file) && ~uselibtt
                 FLATS.GRIDobj2geotiff(flats_file);
@@ -155,7 +155,7 @@ classdef testSnapshot < matlab.unittest.TestCase
         function acv(testCase,dataset)
             A = testCase.dem.acv();
 
-            result_file = fullfile(dataset,"acv.tif");
+            result_file = fullfile("snapshots/data/",dataset,"acv.tif");
 
             if ~isfile(result_file)
                 % Write the result to the directory
@@ -174,7 +174,7 @@ classdef testSnapshot < matlab.unittest.TestCase
                 'verbose', false, ...
                 'internaldrainage',false));
 
-            result_file = fullfile(dataset,"auxtopo.tif");
+            result_file = fullfile("snapshots/data/",dataset,"auxtopo.tif");
 
             if ~isfile(result_file) && ~uselibtt
                 D.GRIDobj2geotiff(result_file);

--- a/tests/testSnapshot.m
+++ b/tests/testSnapshot.m
@@ -1,4 +1,4 @@
-classdef testSnapshot < matlab.unittest.TestCase
+classdef testSnapshot < matlab.perftest.TestCase
     % testSnapshot Snapshot testing using topotoolbox3 as a reference
     % The data for the snapshot tests are available as versioned releases
     % in the TopoToolbox/snapshot_data repository. This repository is added
@@ -109,7 +109,9 @@ classdef testSnapshot < matlab.unittest.TestCase
     methods (Test)
         % Test methods
         function fillsinks(testCase,dataset, uselibtt)
+            testCase.startMeasuring();
             demf = testCase.dem.fillsinks(uselibtt=uselibtt);
+            testCase.stopMeasuring();
 
             result_file = fullfile("snapshots/data/",dataset,"fillsinks.tif");
 
@@ -124,7 +126,10 @@ classdef testSnapshot < matlab.unittest.TestCase
 
         function identifyflats(testCase, dataset, uselibtt)
             demf = testCase.dem.fillsinks(uselibtt=uselibtt);
+
+            testCase.startMeasuring();
             [FLATS, SILLS, CLOSED] = demf.identifyflats();
+            testCase.stopMeasuring();
 
             flats_file = fullfile("snapshots/data/",dataset,"identifyflats_flats.tif");
             sills_file = fullfile("snapshots/data/",dataset,"identifyflats_sills.tif");
@@ -153,7 +158,9 @@ classdef testSnapshot < matlab.unittest.TestCase
         end
 
         function acv(testCase,dataset)
+            testCase.startMeasuring();
             A = testCase.dem.acv();
+            testCase.stopMeasuring();
 
             result_file = fullfile("snapshots/data/",dataset,"acv.tif");
 
@@ -168,11 +175,14 @@ classdef testSnapshot < matlab.unittest.TestCase
 
         function auxtopo(testCase, dataset, uselibtt)
             D = testCase.dem;
+
+            testCase.startMeasuring();
             D.Z = single(createAuxiliaryTopo(testCase.dem, ...
                 'preprocess', 'carve', ...
                 'uselibtt',uselibtt, ...
                 'verbose', false, ...
                 'internaldrainage',false));
+            testCase.stopMeasuring();
 
             result_file = fullfile("snapshots/data/",dataset,"auxtopo.tif");
 

--- a/tests/testSnapshot.m
+++ b/tests/testSnapshot.m
@@ -128,7 +128,7 @@ classdef testSnapshot < matlab.perftest.TestCase
             demf = testCase.dem.fillsinks(uselibtt=uselibtt);
 
             testCase.startMeasuring();
-            [FLATS, SILLS, CLOSED] = demf.identifyflats();
+            [FLATS, SILLS, CLOSED] = demf.identifyflats(uselibtt=uselibtt);
             testCase.stopMeasuring();
 
             flats_file = fullfile("snapshots/data/",dataset,"identifyflats_flats.tif");


### PR DESCRIPTION
This PR implements a benchmark by converting the snapshot tests to use MATLAB's performance testing framework.

The snapshot tests can still be run normally with `runtests("tests/testSnapshot.m")`, but running `runperf("tests/testSnapshot.m")` will collect relevant timing information. A benchmarking task is added to the buildtool, so that `buildtool benchmark` from the MATLAB command window will run the benchmarks and display the results in a table.

The `FLOWobj` test could easily be set up as a benchmark as well -- actually any unit test can be run with `runperf` to collect timing information.

This is not yet hooked up to CI, because the benchmarks are rather expensive, and we need to figure out how often they should be run and how the data should be collected and displayed.