### PR TITLE
Snapshots 1.6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Run MATLAB checks and tests
     env:
-      snapshot_version: v1.5.0
+      snapshot_version: v1.6.0
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR increases the version of the snapshot data repository to v1.6.0, which is the version that now includes the `hillshade` snapshots from #65.