### PR TITLE
Cache MATLAB on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
+          cache: true
           products: >
             Mapping_Toolbox
             Image_Processing_Toolbox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: latest-including-prerelease
+          cache: true
           products: >-
             Mapping_Toolbox
             Image_Processing_Toolbox
@@ -48,8 +49,9 @@ jobs:
         with:
           submodules: true
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v2        
         with:
+          cache: true
           products: >
             Mapping_Toolbox
             Image_Processing_Toolbox


### PR DESCRIPTION
The CI spends a lot of its time in the setup-matlab step. There is a `cache` option to that action that should speed this step up by storing MATLAB and the installed products in an cache.