### PR TITLE
Only use the MATLAB CI cache on ubuntu and macos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          cache: true
+          cache: ${{ matrix.os != 'windows-latest' }}
           products: >
             Mapping_Toolbox
             Image_Processing_Toolbox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: latest-including-prerelease
-          cache: true
+          cache: false
           products: >-
             Mapping_Toolbox
             Image_Processing_Toolbox
@@ -53,7 +53,7 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2        
         with:
-          cache: true
+          cache: ${{ matrix.os != 'windows-latest' }}
           products: >
             Mapping_Toolbox
             Image_Processing_Toolbox


### PR DESCRIPTION
It seems like when we restore the MATLAB installation from the cache, it cannot be found by CMake, which causes the libtopotoolbox compilation step and then haslibtopotoolbox test to fail. This commit sets `cache: true` only on ubuntu and macos runners, requiring a new install of MATLAB on Windows. This is intended as a temporary measure to make sure we avoid CI errors. We might be able to help CMake find the restored cache, but that requires some more detailed investigation.