### PR TITLE
Pass nal and the STREAMobj to the validation function in mapfromnal

### DIFF
--- a/toolbox/@FLOWobj/mapfromnal.m
+++ b/toolbox/@FLOWobj/mapfromnal.m
@@ -44,7 +44,7 @@ function [V,IX] = mapfromnal(FD,S,nal,cl)
 arguments
     FD    FLOWobj
     S     STREAMobj
-    nal   {mustBeGRIDobjOrNal}
+    nal   {mustBeGRIDobjOrNal(nal,S)}
     cl = 'single'
 end
 


### PR DESCRIPTION
This appears to be a syntax error in the validation function: mustBeGRIDobjOrNal requires a STREAMobj as well as the nal. This later throws an error because the STREAMobj argument is undefined.