### PR TITLE
Add an option to skip creating figures in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,4 +50,4 @@ jobs:
       - name: Run checks and tests
         uses: matlab-actions/run-build@v2
         with:
-          tasks: compile check test
+          tasks: compile check test(useGraphics=false)

--- a/buildfile.m
+++ b/buildfile.m
@@ -41,11 +41,19 @@ function checkTask(~)
     assert(isempty(errors));
 end
 
-function testTask(~)
+function testTask(~, options)
+arguments
+    ~
+    options.useGraphics logical = true;
+end
     oldpath = addpath(genpath("toolbox"));
     finalize = onCleanup(@()(path(oldpath)));
 
-    results = runtests("tests","IncludeSubfolders",true);
+    P = matlab.unittest.parameters.Parameter.fromData('graphics', ...
+        {options.useGraphics});
+    suite = matlab.unittest.TestSuite.fromFolder("tests", ...
+        "IncludingSubfolders",true,"ExternalParameters",P);
+    results = run(suite);
     disp(results);
     assertSuccess(results);
 end

--- a/tests/testFLOWobj.m
+++ b/tests/testFLOWobj.m
@@ -6,12 +6,17 @@ classdef testFLOWobj < matlab.unittest.TestCase
         currentFolder = pwd
         tempFolder = fullfile(tempdir,'tt3_testdir')
     end
+
+    properties(ClassSetupParameter)
+        graphics = {true};
+    end
+
     properties (TestParameter)
         files = {'kedarnath','kunashiri','perfectworld','taalvolcano','tibet'};
     end
 
     methods (TestClassSetup)
-        function readFiles(testCase) 
+        function readFiles(testCase, graphics)
 
             % Create a folder in the temporary directory
             if ~exist(testCase.tempFolder,"file")
@@ -45,10 +50,10 @@ classdef testFLOWobj < matlab.unittest.TestCase
     end
 
     % Tests start here ---------------------------------------------------
-    methods (Test, ParameterCombination = 'sequential')
+    methods (Test, ParameterCombination = 'exhaustive')
         % Test methods
 
-        function create_FLOWobj(testCase,files)
+        function create_FLOWobj(testCase, files, graphics)
 				
             % Read example DEM
             fn  = fullfile(testCase.tempFolder,[files '.tif']);
@@ -56,7 +61,9 @@ classdef testFLOWobj < matlab.unittest.TestCase
             
             FD  = FLOWobj(DEM,'multi');
             A   = flowacc(FD);
-            figure; imagesc(log(A)); pause(2); close
+            if graphics
+                figure; imagesc(log(A)); pause(2); close
+            end
             verifyInstanceOf(testCase,FD,'FLOWobj')
         end
 


### PR DESCRIPTION
The figures created in `testFLOWobj` may be useful when running the tests interactively, but on CI we don't check the figures, and it slows things down. This change introduces a `useGraphics` argument to the `test` task so that

```matlab
buildtool test(useGraphics=false)
```

will not try to create the figures in `testFLOWobj`. The `useGraphics` argument sets a `ClassSetupParameter` called `graphics`, which is then used to skip the figure creation code. The `graphics` parameter could also be used in other tests including other classes if desired.

I have also turned the graphics off on CI by default.