### PR TITLE
allowed substrings of the unit argument in STREAMobj

### DIFF
--- a/toolbox/@STREAMobj/STREAMobj.m
+++ b/toolbox/@STREAMobj/STREAMobj.m
@@ -103,6 +103,9 @@ methods
             
             % Dealing with units here
             if ~isGeographic(FD)
+
+                unit = validatestring(unit,{'m', 'km', 'pixels', 'mapunits'});
+
                 switch unit
                     case 'mapunits'
                         minarea = minarea/(FD.cellsize.^2);


### PR DESCRIPTION
S returned an empty STREAMobj when using incorrect/shortened name for the units (e.g. map instead of mapunits.) Used validatestring to convert partial matches into the full correct names of the units. 