### PR TITLE
Run docs build on R2025a explicitly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: latest-including-prerelease
+          release: r2025a
           cache: false
           products: >-
             Mapping_Toolbox


### PR DESCRIPTION
Fixes #87

The latest-including-prerelease version seems not to have recovered from the recent MATLAB outage, but we can use R2025a directly.