### PR TITLE
Add CITATION.cff file and Zenodo DOI badge to README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+title: 'TopoToolbox/topotoolbox3: latest'
+type: software
+version: latest
+authors:
+- affiliation: University of Potsdam
+  given-names: William
+  family-names: Kearney
+- affiliation: University of Potsdam
+  given-names: Wolfgang
+  family-names: Schwanghart
+- family-names: Scherler
+  given-names: Dirk
+- family-names: Arnau
+  given-names: Gina
+- family-names: Ott
+  given-names: Richard
+cff-version: 1.2.0
+date-released: '2025-08-05'
+doi: 10.5281/zenodo.16743005
+license:
+- GPL-3.0-only
+message: If you use this software, please cite it using the metadata from this file.
+repository-code: https://github.com/TopoToolbox/topotoolbox3/tree/latest
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 <img src="images/topotoolbox3.png" align="center">
 
 [![View TopoToolbox on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://de.mathworks.com/matlabcentral/fileexchange/50124-topotoolbox)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16743006.svg)](https://doi.org/10.5281/zenodo.16743006)
+
 
 [TopoToolbox](http://topotoolbox.wordpress.com) is a MATLAB-based software designed for the analysis and visualization of topographic data. It provides a comprehensive set of tools for processing Digital Elevation Models (DEMs), extracting drainage networks, analyzing river profiles, and performing geomorphometric calculations. In addition, TopoToolbox facilitates hydrological modeling and landscape evolution studies. Its efficient algorithms and interactive visualization capabilities allow for detailed analysis of terrain features, helping to understand landscape processes and topographic changes over time.
 


### PR DESCRIPTION
The CITATION.cff file was automatically generated by Zenodo, then lightly edited. Because we currently automatically release `latest` on every commit to main, we won't be able to update this with the DOI for the `latest` release. Therefore, the DOI given in the CITATION.cff file is the "Concept" DOI provided by Zenodo, which will always redirect to the latest release.