### PR TITLE
Rename the automatic releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,10 +90,17 @@ jobs:
           path: release
           pattern: "toolbox-*-*"
           merge-multiple: true
-      - name: Delete latest release if it already exists
-        run: gh release delete latest --yes --cleanup-tag
+      - name: Generate tag
+        id: tag
+        run: |
+          PREFIX="release-$(date +'%Y%m%d')-"
+          MAX=$(git tag -l "${PREFIX}*" | sed -E "s/^${PREFIX}([0-9]+)/\1/" | sort -n | tail -n1)
+          NEXT=$((${MAX:-0} + 1))
+          NEW_TAG="${PREFIX}${NEXT}"
+          echo "TAG=$NEW_TAG" >> $GITHUB_ENV
+          echo "This release will be tagged: $NEW_TAG"
       - name: Create release
         run: |
-          gh release create latest --target main --generate-notes --latest -F .github/latest_release.md
+          gh release create $TAG --target main --generate-notes --latest -F .github/latest_release.md
       - name: Upload toolbox assets        
-        run: gh release upload --repo $GITHUB_REPOSITORY latest release/*
+        run: gh release upload --repo $GITHUB_REPOSITORY $TAG release/*


### PR DESCRIPTION
Creating and deleting the latest tag does not play well with Zenodo, so we will instead create releases numbered

release-YYYYMMDD-N

where N is a number that increases for every release, so we can have more than one per day. There is a little bit of effort required to figure out what that number should be. Otherwise everything is the same. The release will show up under the Release section on the landing page with the latest tag, so it should not be too onerous to find for users, even if the release number is a little intimidating.