### PR TITLE
Update CITATION.cff with new release numbers

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
-title: 'TopoToolbox/topotoolbox3: latest'
+title: 'TopoToolbox/topotoolbox3: release-20250805-2'
 type: software
-version: latest
+version: release-20250805-2
 authors:
 - affiliation: University of Potsdam
   given-names: William


### PR DESCRIPTION
Changing the release numbers did not actually trigger a new release on Zenodo, and I am wondering if we need to update the CITATION.cff to get a new release labeled.