### PR TITLE
Fix yet another typo in the workflow file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
   package:
     if: github.repository == 'TopoToolbox/topotoolbox3'
     name: Package toolbox
-    needs: docs release
+    needs: [docs, release]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
These are not getting caught until we try to run the release workflow. Apologies for the volume of PRs.