### PR TITLE
update to readopentopo

### DIFF
--- a/toolbox/@FLOWobj/flowacc.m
+++ b/toolbox/@FLOWobj/flowacc.m
@@ -87,7 +87,7 @@ if ~(exist(['flowacc_mex.' mexext],'file') == 3 && nargin<3 && strcmp(FD.type,'s
     ix = FD.ix;
     ixc = FD.ixc;
     
-    switch FD.type
+    switch lower(FD.type)
         case 'single'
             if nargin < 3
                 
@@ -98,15 +98,9 @@ if ~(exist(['flowacc_mex.' mexext],'file') == 3 && nargin<3 && strcmp(FD.type,'s
                 if isscalar(RR)
                     % if RR is a scalar, RR is assumed to be the
                     % coefficient of a homogenous differential equation
-                    % dA/dx = RR*A
-                    %
-                    % A1/A2 = A0exp(RR*x1)/A0exp(RR*x2)
-                    %       = exp(RR*x1)/exp(RR*x2)
-                    %       = exp(RR*(x1-x2))
-                    %       = exp(RR*dx)
                     
                     dx = getdistance(ix,ixc,FD.size,FD.cellsize);
-                    RR = exp(RR*dx);
+                    RR = RR.^dx;
                     clear dx
                     
                     for r = 1:numel(ix)
@@ -121,7 +115,7 @@ if ~(exist(['flowacc_mex.' mexext],'file') == 3 && nargin<3 && strcmp(FD.type,'s
                 
             end
             
-        case {'multi','Dinf'}
+        case {'multi','dinf'}
             fraction = FD.fraction;
             if nargin < 3
                 for r = 1:numel(ix)

--- a/toolbox/IOtools/hydrosheds2FLOWobj.m
+++ b/toolbox/IOtools/hydrosheds2FLOWobj.m
@@ -24,8 +24,8 @@ function FD = hydrosheds2FLOWobj(file)
 %
 % See also: FLOWobj, GRIDobj
 %
-% Author: Wolfgang Schwanghart (w.schwanghart[at]geo.uni-potsdam.de)
-% Date: 26. April, 2018
+% Author: Wolfgang Schwanghart (schwangh[at]uni-potsdam.de)
+% Date: 1. August, 2025
 
 if isa(file,'GRIDobj')
     FDIR = file;

--- a/toolbox/IOtools/roipicker.m
+++ b/toolbox/IOtools/roipicker.m
@@ -41,9 +41,9 @@ function ext = roipicker(options)
 %
 % See also: readopentopo, readopenalti
 %
-% Authors:  Wolfgang Schwanghart (w.schwanghart[at]geo.uni-potsdam.de)
+% Authors:  Wolfgang Schwanghart (schwangh[at]uni-potsdam.de)
 %
-% Date: 28. September, 2022
+% Date: 20. August, 2025
 
 arguments
     options.basemap = 'topographic'


### PR DESCRIPTION
This pull request resolves issue https://github.com/TopoToolbox/topotoolbox3/issues/9. `readopentopo` now uses `prefdir` to permanently store user API keys to access opentopography.org data. 