### PR TITLE
Bug removed in chiplot

### DIFF
--- a/toolbox/@STREAMobj/chiplot.m
+++ b/toolbox/@STREAMobj/chiplot.m
@@ -177,6 +177,7 @@ zx   = ezgetnal(S,DEM,'double');
 zb   = zx(outlet);
 
 a = ezgetnal(S,A)*(A.cellsize.^2); 
+a = a0./a;
 
 % x is the cumulative horizontal distance in upstream direction
 x    = S.distance;


### PR DESCRIPTION
chiplot had a bug that caused that the function integrated upstream area instead of its inverse. This commit resolves this bug.