### PR TITLE
Create a package without libtopotoolbox

### DIFF
--- a/.github/latest_release.md
+++ b/.github/latest_release.md
@@ -9,5 +9,6 @@ operating system:
 - TopoToolbox_glnxa64.mltbx - 64-bit Linux platform
 - TopoToolbox_maci64.mltbx - 64-bit macOS platform
 - TopoToolbox_maca64.mltbx - 64-bit macOS platform, Apple silicon
+- TopoToolbox_nolibtt.mltbx - Platform-agnostic without libtopotoolbox
 
 and open it in MATLAB.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,6 +79,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        mex: [ true ]
+        include:
+          - os: windows-latest
+            mex: false
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
@@ -102,10 +106,19 @@ jobs:
         with:
           name: toolbox-docs
           path: toolbox/docs/html/
+      - name: Build MEX files
+        if: ${{ matrix.mex }}
+        uses: matlab-actions/run-build@v2
+        with:
+          tasks: compile
       - name: Build package
         uses: matlab-actions/run-build@v2
         with:
-          tasks: compile package
+          tasks: package
+      - name: Move un-compiled package to one with a generic name
+        if: ${{ ! matrix.mex }}
+        shell: bash
+        run: mv release/TopoToolbox_win64.mltbx release/TopoToolbox_nolibtt.mltbx
       - name: Upload toolbox as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/buildfile.m
+++ b/buildfile.m
@@ -2,12 +2,18 @@ function plan = buildfile
     plan = buildplan(localfunctions);
     
     plan("package") = matlab.buildtool.Task( ...
+        Dependencies = "mexDirectory", ...
         Description = "Package toolbox", ...
         Actions = @packageToolbox);
 
     plan("benchmark").Dependencies = "compile";
 
     plan.DefaultTasks = ["check" "test" "package"];
+end
+
+function mexDirectoryTask(~)
+    [status, msg, msgid] = mkdir("toolbox/internal/mex");
+    assert(status == 1);
 end
 
 function checkTask(~)


### PR DESCRIPTION
The release.yaml workflow has been updated to create a new MLTBX package called TopoToolbox_nolibtt.mltbx that does not include the compiled MEX files.

The buildfile is updated with a new task to make sure that the toolbox/internal/mex directory is created in case we do not compile the MEX files. Without this, the package task errors because it tries to export this directory, which doesn't exist.

The release notes are also updated.

----

This resolves #122.

The release.yaml includes a bit of a hack to get the mltbx file named correctly: it creates it on Windows with the same file name as the usual Windows toolbox and then moves it to TopoToolbox_nolibtt.mltbx.

We can call the toolbox file something different as well. I worried that just calling it TopoToolbox.mltbx might confuse people trying to download it from our Releases page.