### PR TITLE
Rename build artifacts so nolibtt doesn't overwrite windows-latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Upload toolbox as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: toolbox-${{ matrix.os }}-${{ matrix.release }}
+          name: toolbox-${{ matrix.os }}-${{ matrix.mex }}
           path: release/TopoToolbox_*.mltbx
       - name: Upload toolbox assets
         shell: bash


### PR DESCRIPTION
The last few automatic releases have failed to upload a Windows mltbx file because the nolibtt and windows-latest artifact names collide. This adds the mex flag to the artifact name so this won't happen.

The `matrix.release` variable was never defined, so this actually doesn't work. Since the artifacts are uploaded per workflow, we don't really need to label them with the release number. The artifact names are purely internal.