### PR TITLE
Cache downloaded data files

### DIFF
--- a/toolbox/IOtools/readexample.m
+++ b/toolbox/IOtools/readexample.m
@@ -37,8 +37,8 @@ function DEM = readexample(example,options)
 
 arguments
     example 
-    options.filename = [tempname '.tif']
-    options.deletefile (1,1) = true
+    options.filename = fullfile(ttcachedir, strcat(example, '.tif'))
+    options.deletefile (1,1) = false
     options.verbose (1,1) = true
 end
 
@@ -46,6 +46,13 @@ example = lower(example);
 
 % create file to which the data will be saved
 f = fullfile(options.filename);
+
+% If the file already exists, open and return it.
+if isfile(f)
+    DEM = GRIDobj(f);
+    DEM.name = example;
+    return;
+end
 
 switch example
     case 'taiwan'

--- a/toolbox/IOtools/readopenalti.m
+++ b/toolbox/IOtools/readopenalti.m
@@ -77,7 +77,7 @@ function data = readopenalti(options)
 % Date: 12. September, 2024
 
 arguments
-    options.filename = [tempname '.csv']
+    options.filename = strcat(tempname(ttcachedir), '.csv')
     options.interactive = false
     options.addmargin = 0.01 %°
     options.extent   = []

--- a/toolbox/IOtools/readopentopo.m
+++ b/toolbox/IOtools/readopentopo.m
@@ -121,7 +121,7 @@ arguments
      'NASADEM','COP30','COP90',...
      'EU_DTM','GEDI_L3','GEBCOSubIceTopo','GEBCOIceTopo',...
      'CA_MRDEM_DSM','CA_MRDEM_DTM'})} = 'SRTMGL3'
-    options.filename = [char(tempname) '.tif']
+    options.filename = ''
     options.interactive (1,1) = false
     options.extent = []
     options.addmargin (1,1) = 0.01
@@ -129,7 +129,7 @@ arguments
     options.south (1,1) = 36.738884
     options.west  (1,1) = -120.168457
     options.east  (1,1) = -119.465576
-    options.deletefile (1,1) = true
+    options.deletefile (1,1) = false
     options.verbose (1,1) = true
     options.apikey  = ''
     options.checkrequestlimit (1,1) = true
@@ -160,8 +160,32 @@ requestlimit  = requestlimits(strcmp(demtype,validdems));
 % API URL
 url = 'https://portal.opentopography.org/API/globaldem?';
 
+if options.filename == ""
+    options.filename = fullfile(ttcachedir, strcat("OpenTopo_", ...
+        string(options.south), "_", ...
+        string(options.north), "_", ...
+        string(options.west), "_", ...
+        string(options.east), "_", options.demtype, ".tif"));
+end
+
 % create output file
 f = fullfile(options.filename);
+
+% If the file already exists, open and return it
+if isfile(f)
+    DEM = GRIDobj(f);
+    
+    if ~isProjected(DEM)
+        disp(' ')
+        disp('The downloaded DEM is not in a projected coordinate system.')
+        disp('Make sure to project the DEM using GRIDobj/project or')
+        disp('GRIDobj/reproject2utm.')
+        disp('  ')
+    end
+    
+    DEM.name = demtype;
+    return;
+end
 
 % check api
 options.apikey = strip(options.apikey);

--- a/toolbox/IOtools/ttcachedir.m
+++ b/toolbox/IOtools/ttcachedir.m
@@ -1,0 +1,73 @@
+function cachedir = ttcachedir(options)
+%TTCACHEDIR Return the platform-specific cache directory for TopoToolbox 3
+%
+% Description
+%
+%     The default storage location for downloaded data is ttcachedir. Use
+%     ttclearcache to delete files from the cache. The default storage
+%     location is
+%
+%     Windows:
+%         %LOCALAPPDATA%\topotoolbox
+%
+%     macOS:
+%         $HOME/Library/Caches/topotoolbox
+%
+%     Linux:
+%         $XDG_CACHE_HOME/topotoolbox
+%
+%     If this directory does not exist, ttcachedir will try to create it.
+%     If another location should be used for the cache, supply the cachedir
+%     argument.
+%
+% Input arguments
+%
+%     Parameter name/value pairs
+%
+%     'cachedir'   char or string. If supplied, ttcachedir will use this
+%     directory instead of the default one.
+%
+% Author: William Kearney (william.kearney[at]uni-potsdam.de)
+% Date: 30 March 2026
+
+arguments
+    options.cachedir = ''
+end
+
+if isempty(options.cachedir)
+
+    if ispc()
+        if ~isenv("LOCALAPPDATA")
+            error("Please set environment variable LOCALAPPDATA or supply " + ...
+                "cachedir argument to ttcachedir");
+        end
+        cachedir = getenv("LOCALAPPDATA");
+    elseif isunix()
+        if ismac()
+            if isenv("HOME")
+                cachedir = fullfile(getenv("HOME"),"Library","Caches");
+            else
+                error("Please set environment variable HOME or supply " + ...
+                    "cachedir argument to ttcachedir");
+            end
+        else
+            cachedir = getenv("XDG_CACHE_HOME");
+            if isempty(cachedir)
+                if isenv("HOME")
+                    cachedir = fullfile(getenv("HOME"), ".cache");
+                else
+                    error("Please set environment variable HOME or supply " + ...
+                        "cachedir argument to ttcachedir");
+                end
+            end
+        end
+    end
+
+    cachedir = fullfile(cachedir, "topotoolbox");
+else
+    cachedir = options.cachedir;
+end
+
+if ~isfolder(cachedir)
+    mkdir(cachedir);
+end

--- a/toolbox/IOtools/ttclearcache.m
+++ b/toolbox/IOtools/ttclearcache.m
@@ -1,0 +1,30 @@
+function ttclearcache(options)
+%TTCLEARCACHE Clear the local TopoToolbox cache directory
+%
+% Description
+%
+%     Deletes the cache directory and all the files in it. The default
+%     cache directory as returned by ttcachedir will be returned unless
+%     the cachedir option is provided, in which case that directory will be
+%     cleared instead.
+%
+% Input arguments
+%
+%     Parameter name/value pairs
+%
+%     'cachedir'   char or string. If supplied, ttclearcache will use this
+%     directory instead of the default one.
+%
+% Author: William Kearney (william.kearney[at]uni-potsdam.de)
+% Date: 30 March 2026
+
+arguments
+    options.cachedir (1,1) = ttcachedir
+end
+
+if isfolder(options.cachedir)
+    rmdir(options.cachedir,'s');
+end
+
+
+end


### PR DESCRIPTION
Resolves #151

This PR adds two functions to the IOtools:

- `ttcachedir` returns the name of a platform-specific cache directory
- `ttclearcache` deletes that directory to clear the cache

`readopentopo`, `readexample` and `readopenalti` are modified to use `ttcachedir` instead of `tempname` when generating the files.

The new behavior of `ttcachedir`, `readopentopo` and `readexample` follows that of their counterparts in pytopotoolbox. The default cache directories are

- Windows: %LOCALAPPDATA%\topotoolbox
- macOS: $HOME/Library/Caches/topotoolbox
- Linux: $XDG_CACHE_HOME/topotoolbox (defaults to $HOME/.cache/topotoolbox if $XDG_CACHE_HOME is undefined)

If the necessary environment variables (i.e. %LOCALAPPDATA%) don't exist, an error is thrown, but if the directory doesn't exist, it is created by `ttcachedir`. I've included an option for the user to supply a custom cache directory to `ttcachedir` and `ttclearcache`, but this option is not exposed at the moment to `readopentopo`, etc. because I didn't want to modify the input arguments to those functions too much. If the cache directory doesn't exist when you call `readopentopo`, you'll get an error from `ttcachedir`, which is probably more confusing than it should be.

The default name of the OpenTopography files is changed to match pytopotoolbox, which in turn follows the CSDMS bmi_topography tool's naming convention. It is

OpenTopo_$SOUTH_$NORTH_$WEST_$EAST_$DEMTYPE.tif

This could use more testing, especially on Windows and macOS platforms. 
