### PR TITLE
Pin reusable workflow versions for matlab-actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           submodules: true
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v 3.0.1
         with:
           release: ${{ matrix.matlab-version }}
           cache: ${{ matrix.os != 'windows-latest' }}
@@ -50,6 +50,6 @@ jobs:
         run:
           shasum -c --status sha256sum.txt
       - name: Run checks and tests
-        uses: matlab-actions/run-build@v2
+        uses: matlab-actions/run-build@e6fa4ea64b81a3a277395febd62db266faca1d0c # v 3.1.1
         with:
           tasks: compile check test(useGraphics=false)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           submodules: true
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v 3.0.1
         with:
           release: r2025a
           cache: false
@@ -58,11 +58,11 @@ jobs:
             Optimization_Toolbox
             MATLAB_Coder
       - name: Compile libtopotoolbox and MEX files
-        uses: matlab-actions/run-build@v2
+        uses: matlab-actions/run-build@e6fa4ea64b81a3a277395febd62db266faca1d0c # v 3.1.1
         with:
           tasks: compile
       - name: Build docs
-        uses: matlab-actions/run-build@v2
+        uses: matlab-actions/run-build@e6fa4ea64b81a3a277395febd62db266faca1d0c # v 3.1.1
         with:
           tasks: doc
       - name: Upload docs as artifact
@@ -93,7 +93,7 @@ jobs:
         with:
           submodules: true
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2        
+        uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v 3.0.1
         with:
           cache: ${{ matrix.os != 'windows-latest' }}
           products: >
@@ -108,11 +108,11 @@ jobs:
           path: toolbox/docs/html/
       - name: Build MEX files
         if: ${{ matrix.mex }}
-        uses: matlab-actions/run-build@v2
+        uses: matlab-actions/run-build@e6fa4ea64b81a3a277395febd62db266faca1d0c # v 3.1.1
         with:
           tasks: compile
       - name: Build package
-        uses: matlab-actions/run-build@v2
+        uses: matlab-actions/run-build@e6fa4ea64b81a3a277395febd62db266faca1d0c # v 3.1.1
         with:
           tasks: package
       - name: Move un-compiled package to one with a generic name


### PR DESCRIPTION
Closes #148

These versions should work with the new Node version.