### PR TITLE
Additional argument checks for graphflood

### DIFF
--- a/toolbox/@GRIDobj/graphflood.m
+++ b/toolbox/@GRIDobj/graphflood.m
@@ -107,6 +107,7 @@ if isnumeric(options.manning) && isscalar(options.manning)
 else
     validatealignment(DEM,options.manning)
     manning = options.manning;
+    manning.Z = double(manning.Z);
 end
 
 % BCs


### PR DESCRIPTION
This PR changes graphflood to resolve issue https://github.com/TopoToolbox/topotoolbox3/issues/165. The function now ensures that the underlying class of a Manning-GRIDobj is converted to double before passed to tt_graphflood.