### PR TITLE
Use latest release to build docs.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v 3.0.1
         with:
-          release: r2025a
+          release: latest
           cache: false
           products: >-
             Mapping_Toolbox


### PR DESCRIPTION
For some reason, the setup-matlab action doesn't like the R2025a label. This should work with the newer release, though.