### PR TITLE
Cleaning documentation

### DIFF
--- a/toolbox/@DIVIDEobj/divorder.m
+++ b/toolbox/@DIVIDEobj/divorder.m
@@ -30,7 +30,7 @@ function DOUT = divorder(DIN,varargin)
 % Example
 %     
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     ST = STREAMobj(FD,flowacc(FD)>1000);
 %     D = DIVIDEobj(FD,ST);
 %     D = sort(D);

--- a/toolbox/@DIVIDEobj/getvalue.m
+++ b/toolbox/@DIVIDEobj/getvalue.m
@@ -35,7 +35,7 @@ function varargout = getvalue(D,GRID,fct)
 % Example
 %     
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     ST = STREAMobj(FD,flowacc(FD)>1000);
 %     D = DIVIDEobj(FD,ST);
 %     D = divorder(D,'topo');

--- a/toolbox/@DIVIDEobj/jctcon.m
+++ b/toolbox/@DIVIDEobj/jctcon.m
@@ -33,7 +33,7 @@ function [CJ,varargout] = jctcon(D,varargin)
 % Examples
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     ST = STREAMobj(FD,flowacc(FD)>1000);
 %     D = DIVIDEobj(FD,ST);
 %     D = divorder(D,'topo');

--- a/toolbox/@DIVIDEobj/plotc.m
+++ b/toolbox/@DIVIDEobj/plotc.m
@@ -50,7 +50,7 @@ function varargout = plotc(D,val,varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     ST = STREAMobj(FD,flowacc(FD)>1000);
 %     D = DIVIDEobj(FD,ST);
 %     D = divorder(D,'topo');

--- a/toolbox/@FLOWobj/FLOWobj2GRIDobj.m
+++ b/toolbox/@FLOWobj/FLOWobj2GRIDobj.m
@@ -25,7 +25,7 @@ function G = FLOWobj2GRIDobj(F)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     ArcFlow = FLOWobj2GRIDobj(FD);
 %     imagesc(ArcFlow)
 %

--- a/toolbox/@FLOWobj/FLOWobj2M.m
+++ b/toolbox/@FLOWobj/FLOWobj2M.m
@@ -22,7 +22,7 @@ function M = FLOWobj2M(FD)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     M = FLOWobj2M(FD);
 %     [x,y] = getcoordinates(DEM);
 %     [x,y] = meshgrid(x,y);

--- a/toolbox/@FLOWobj/FLOWobj2cell.m
+++ b/toolbox/@FLOWobj/FLOWobj2cell.m
@@ -32,7 +32,7 @@ function [CFD,D,A,cfix] = FLOWobj2cell(FD,IX)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     [CFD,~,a] = FLOWobj2cell(FD);
 %     [~,ix] = max(a);
 %     A = flowacc(CFD{ix});

--- a/toolbox/@FLOWobj/dependencemap.m
+++ b/toolbox/@FLOWobj/dependencemap.m
@@ -31,7 +31,7 @@ function OUT = dependencemap(FD,varargin)
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
 %     I   = GRIDobj(DEM,'logical');
 %     I.Z(300:500,300:500) = true;
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     D  = dependencemap(FD,I);
 %     imageschs(DEM,I+D)
 %

--- a/toolbox/@FLOWobj/drainagebasinstats.m
+++ b/toolbox/@FLOWobj/drainagebasinstats.m
@@ -46,7 +46,7 @@ function stats = drainagebasinstats(FD,L,varargin)
 % Example: Plot the distribution of mean gradients upstream of channelheads
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     ix = streampoi(S,'channelheads','ix');
 %     G  = gradient8(DEM);

--- a/toolbox/@FLOWobj/flowconvergence.m
+++ b/toolbox/@FLOWobj/flowconvergence.m
@@ -25,7 +25,7 @@ function N = flowconvergence(FD)
 % Example
 % 
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     C  = flowconvergence(FD);
 %     imageschs(DEM,C)
 %

--- a/toolbox/@FLOWobj/flowpathextract.m
+++ b/toolbox/@FLOWobj/flowpathextract.m
@@ -53,7 +53,7 @@ function [ixchannel,d,x,y] = flowpathextract(FD,ixchannel,A,stopcrit)
 % Example
 % 
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     [IXc,d] = flowpathextract(FD,473962);
 %     plot(d,DEM.Z(IXc))
 %

--- a/toolbox/@FLOWobj/gradient.m
+++ b/toolbox/@FLOWobj/gradient.m
@@ -28,7 +28,7 @@ function G = gradient(FD,DEM)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     G  = gradient(FD,DEM);
 %     imageschs(DEM,G)
 %

--- a/toolbox/@FLOWobj/imposemin.m
+++ b/toolbox/@FLOWobj/imposemin.m
@@ -37,7 +37,7 @@ function DEM = imposemin(FD,DEM,sl)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     DEMc = imposemin(FD,DEM);
 %     imageschs(DEM,DEM-DEMc,'colormap',flipud(parula)) 
 %

--- a/toolbox/@FLOWobj/influencemap.m
+++ b/toolbox/@FLOWobj/influencemap.m
@@ -27,7 +27,7 @@ function OUT = influencemap(FD,varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     I  = influencemap(FD,540261);
 %     imageschs(DEM,dilate(I,ones(5)));
 %

--- a/toolbox/@FLOWobj/ismulti.m
+++ b/toolbox/@FLOWobj/ismulti.m
@@ -20,7 +20,7 @@ function tf = ismulti(FD,typetest)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     ismulti(FD)
 % 
 %     ans =

--- a/toolbox/@FLOWobj/streamorder.m
+++ b/toolbox/@FLOWobj/streamorder.m
@@ -47,7 +47,7 @@ function OUT = streamorder(FD,WW,type)
 % Example:
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S = streamorder(FD,flowacc(FD)>1000);
 %     imagesc(S)
 % 

--- a/toolbox/@FLOWobj/upslopestats.m
+++ b/toolbox/@FLOWobj/upslopestats.m
@@ -35,7 +35,7 @@ function OUT = upslopestats(FD,VAR,meth,S)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     G  = gradient8(DEM);
 %     Gup = upslopestats(FD,G,'mean');
 %     imageschs(DEM,Gup,'caxis',[0 1])

--- a/toolbox/@FLOWobj/vertdistance2stream.m
+++ b/toolbox/@FLOWobj/vertdistance2stream.m
@@ -25,7 +25,7 @@ function DZ = vertdistance2stream(FD,S,DEM)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1e6,'unit','m');
 %     DZ = vertdistance2stream(FD,S,DEM);
 %     imageschs(DEM,DZ)

--- a/toolbox/@GRIDobj/GRIDobj2polygon.m
+++ b/toolbox/@GRIDobj/GRIDobj2polygon.m
@@ -57,7 +57,7 @@ function [MS,x,y] = GRIDobj2polygon(DB,options)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     D = drainagebasins(FD);
 %     [MS,x,y] = GRIDobj2polygon(D,'Geometry','Line','simplify',true,'tol',0);
 %     imageschs(DEM,DEM,'colormap','landcolor')

--- a/toolbox/@GRIDobj/postprocflats.m
+++ b/toolbox/@GRIDobj/postprocflats.m
@@ -33,7 +33,7 @@ function FA = postprocflats(FLATS,FA,fun)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     A  = flowacc(FD);
 %     I  = identifyflats(fillsinks(DEM));
 %     FA = postprocflats(I,A,@max);

--- a/toolbox/@PPS/cdftest.m
+++ b/toolbox/@PPS/cdftest.m
@@ -33,7 +33,7 @@ function varargout = cdftest(P,varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = klargestconncomps(S,1);
 %     P = PPS(S,'runif',100,'z',DEM);

--- a/toolbox/@PPS/density.m
+++ b/toolbox/@PPS/density.m
@@ -62,7 +62,7 @@ function [h,bw] = density(P,options)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = klargestconncomps(S,1);
 %     rng(2); % make results replicable

--- a/toolbox/@PPS/ecdf.m
+++ b/toolbox/@PPS/ecdf.m
@@ -58,7 +58,7 @@ function varargout = ecdf(P,options)
 % Example
 %
 %      DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%      FD  = FLOWobj(DEM,'preprocess','c');
+%      FD  = FLOWobj(DEM);
 %      S = STREAMobj(FD,'minarea',1000);
 %      S = klargestconncomps(S,1);
 %      P = PPS(S,'runif',100,'z',DEM);

--- a/toolbox/@PPS/fitloglinear.m
+++ b/toolbox/@PPS/fitloglinear.m
@@ -54,7 +54,7 @@ function [mdl,int,rts,rtssigma,ismx,sigmapred] = fitloglinear(P,c,varargin)
 %          and fit the model.
 % 
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = klargestconncomps(S,1);
 %     P = PPS(S,'PP',[],'z',DEM);
@@ -74,7 +74,7 @@ function [mdl,int,rts,rtssigma,ismx,sigmapred] = fitloglinear(P,c,varargin)
 %            loglinear model.
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = klargestconncomps(S,1);
 %     

--- a/toolbox/@PPS/idw.m
+++ b/toolbox/@PPS/idw.m
@@ -37,7 +37,7 @@ function c = idw(P,marks,varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = removeshortstreams(S,100);
 %     S = clean(S);

--- a/toolbox/@PPS/modify.m
+++ b/toolbox/@PPS/modify.m
@@ -31,7 +31,7 @@ function [P,nalix,markix] = modify(P,varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = removeshortstreams(S,100);
 %     S = clean(S);

--- a/toolbox/@PPS/plotpoints.m
+++ b/toolbox/@PPS/plotpoints.m
@@ -40,7 +40,7 @@ function h = plotpoints(P,varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = removeshortstreams(S,100);
 %     S = clean(S);

--- a/toolbox/@PPS/pointdistances.m
+++ b/toolbox/@PPS/pointdistances.m
@@ -38,7 +38,7 @@ function d = pointdistances(P,options)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = removeshortstreams(S,100);
 %     S = clean(S);

--- a/toolbox/@PPS/rhohat.m
+++ b/toolbox/@PPS/rhohat.m
@@ -64,7 +64,7 @@ function s = rhohat(P,varargin)
 %          chi
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = klargestconncomps(S,1);
 %     [~,kp] = knickpointfinder(S,DEM,'tol',30,'split',false);

--- a/toolbox/@STREAMobj/cumtrapz.m
+++ b/toolbox/@STREAMobj/cumtrapz.m
@@ -6,6 +6,7 @@ function z = cumtrapz(S,G,options)
 %
 %     z = cumtrapz(S,G)
 %     z = cumtrapz(S,g)
+%     z = cumtrapz(S,g,'distance',d,'uselibtt',tf)
 %
 % Description
 %
@@ -22,6 +23,9 @@ function z = cumtrapz(S,G,options)
 %
 %     Parameter name/value pairs
 %     
+%     'distance' - {distance(S,'node_to_node')}
+%          a node attribute list with inter-node distances between a node
+%          and its downstream neighbor. 
 %     'uselibtt' - {true},false
 %          if true, then cumtrapz will be calculated using functions in
 %          libtopotoolbox. If false, then native MATLAB code will be used.
@@ -30,16 +34,33 @@ function z = cumtrapz(S,G,options)
 %
 %     z     node attribute list
 %
-% Example
+% Example 1
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','carve');
+%     FD = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     A = flowacc(FD);
 %     a = getnal(S,A)*DEM.cellsize^2;
 %     ghat = 1./(a.^0.45);
 %     z = cumtrapz(S,ghat);
 %     plotdz(S,z)
+%
+% Example 2
+%
+%     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
+%     FD = FLOWobj(DEM);
+%     S = STREAMobj(FD,'minarea',1000);
+%     S = klargestconncomps(S);
+%     A = flowacc(FD);
+%     c = chitransform(S,A);
+%     dc = diff(S,c);
+%     ghat = smooth(S,rand(size(S.x)),'K',20);
+%     ghat = normalize(ghat,'range',[0 1]);
+%     ix = randlocs(S,20);
+%     ghat(ismember(S.IXgrid,ix)) = 20;
+%     z = cumtrapz(S,ghat,'distance',dc);
+%     [~,zb] = zerobaselevel(S,DEM);
+%     plotdz(S,z+zb)
 %
 % See also: STREAMobj, STREAMobj/gradient
 %
@@ -48,19 +69,23 @@ function z = cumtrapz(S,G,options)
 
 arguments
     S   STREAMobj
-    G   {mustBeGRIDobjOrNal(G,S)}
+    G   {mustBeGRIDobjOrNalOrScalar(G,S)}
+    options.distance = distance(S,'node_to_node')
     options.uselibtt (1,1) = (true && haslibtopotoolbox)
 end
 
 % get node attribute list with elevation values
 if isa(G,"GRIDobj")
     g = ezgetnal(S,G,underlyingType(G));
+elseif isscalar(G)
+    g = ezgetnal(S,G,class(G));
 else
     g = G;
 end
 
 % get inter-node distances as edge properties
-d = distance(S,'node_to_node');
+d = options.distance;
+validateattributes(d,{'numeric'},{'size',size(S.x)});
 d = d(S.ix);
 
 ix  = S.ix;

--- a/toolbox/@STREAMobj/diff.m
+++ b/toolbox/@STREAMobj/diff.m
@@ -28,7 +28,7 @@ function dz = diff(S,z,fillval)
 % Example: Calculate elevation offsets along stream network
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S = trunk(klargestconncomps(S));
 %     dz = diff(S,DEM);

--- a/toolbox/@STREAMobj/extractconncomps.m
+++ b/toolbox/@STREAMobj/extractconncomps.m
@@ -19,7 +19,7 @@ function extractconncomps(S)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S  = STREAMobj(FD,A>1000);
 %     extractconncomps(S)
 %

--- a/toolbox/@STREAMobj/gradient.m
+++ b/toolbox/@STREAMobj/gradient.m
@@ -48,7 +48,7 @@ function s = gradient(S,DEM,options)
 % Example 1
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S  = STREAMobj(FD,'minarea',1000);
 %     S  = klargestconncomps(trunk(S));
 %     g  = gradient(S,DEM,'method','robust');
@@ -58,7 +58,7 @@ function s = gradient(S,DEM,options)
 % Example 2: Using the gradient function to calculate a Ksn map
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S  = STREAMobj(FD,'minarea',1000);    
 %     c = chitransform(S,A,'mn',0.45,'a0',1);
 %     k = gradient(S,z,'distance',c);

--- a/toolbox/@STREAMobj/identifyflats.m
+++ b/toolbox/@STREAMobj/identifyflats.m
@@ -27,7 +27,7 @@ function [fs,s] = identifyflats(S,DEM)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S  = STREAMobj(FD,A>1000);
 %     S  = klargestconncomps(trunk(S));
 %     DEM = fillsinks(DEM);

--- a/toolbox/@STREAMobj/imposemin.m
+++ b/toolbox/@STREAMobj/imposemin.m
@@ -44,7 +44,7 @@ function DEM = imposemin(S,DEM,sl)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S  = STREAMobj(FD,A>1000);
 %     S  = klargestconncomps(trunk(S));
 %     plotdz(S,DEM)

--- a/toolbox/@STREAMobj/interp.m
+++ b/toolbox/@STREAMobj/interp.m
@@ -1,4 +1,4 @@
-function zi = interp(S,d,z,varargin)
+function zi = interp(S,d,z,method,extrapolation)
 
 %INTERP Interpolate data on STREAMobj (single river only)
 %
@@ -26,7 +26,7 @@ function zi = interp(S,d,z,varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S   = STREAMobj(FD,'minarea',1000);
 %     S   = trunk(klargestconncomps(S));
 %     zi = interp(S,[10000 12000 20000 39000 40000],[5 10 20 6 10],...
@@ -36,19 +36,32 @@ function zi = interp(S,d,z,varargin)
 % See also: STREAMobj, STREAMobj/trunk, demo_modifystreamnet
 %
 % Author: Wolfgang Schwanghart (schwangh[at]uni-potsdam.de)
-% Date: 18. February, 2019
+% Date: 11. June, 2026
 
+arguments
+    S {mustBeSingleRiver}
+    d 
+    z {mustHaveEqualSize(z,d)}
+    method = 'linear'
+    extrapolation = 'extrap'
+end
 
-p = inputParser;
-addRequired(p,'S',@(x) numel(streampoi(x,'channelheads','ix')) == 1);
-addRequired(p,'d')
-addRequired(p,'z',@(x) isequal(size(x),size(d)));
-addOptional(p,'method','linear',@(x) ischar(x) || isstring(x));
-addOptional(p,'extrapolation','extrap',@(x) ischar(x) || isstring(x) || isscalar(x));
-parse(p,S,d,z,varargin{:});
-S   = p.Results.S;
 
 [d,ix] = sort(d,'ascend');
 z = z(ix);
 
-zi = interp1(d,z,S.distance,p.Results.method,p.Results.extrapolation);
+zi = interp1(d,z,S.distance,method,extrapolation);
+
+end
+
+function mustBeSingleRiver(S)
+if numel(streampoi(S,'channelheads','ix')) ~= 1
+    error('STREAMobj must contain a single stream.')
+end
+end
+
+function mustHaveEqualSize(x,y)
+if numel(x) ~= numel(y)
+    error('d and z must have the same number of elements.')
+end
+end

--- a/toolbox/@STREAMobj/intersect.m
+++ b/toolbox/@STREAMobj/intersect.m
@@ -26,7 +26,7 @@ function S = intersect(varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     A  = flowacc(FD);
 %     S  = STREAMobj(FD,A>1000);
 %     % get trunk streams of streamorder 3

--- a/toolbox/@STREAMobj/intersectlocs.m
+++ b/toolbox/@STREAMobj/intersectlocs.m
@@ -39,7 +39,7 @@ function varargout = intersectlocs(S1,S2)
 %     % http://topotoolbox.wordpress.com/2014/09/09/landslides-hit-rivers/
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c','mex',true);
+%     FD = FLOWobj(DEM);
 %     S = STREAMobj(FD,flowacc(FD)>1000);
 %     LS = GRIDobj(DEM);
 %     LS.Z = logical(LS.Z);

--- a/toolbox/@STREAMobj/isequal.m
+++ b/toolbox/@STREAMobj/isequal.m
@@ -28,7 +28,7 @@ function tf = isequal(S1,S2,type)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     S = STREAMobj(FD,'minarea',1000);
 %     S2 = trunk(S);
 %     isequal(S,S2)    

--- a/toolbox/@STREAMobj/klargestconncomps.m
+++ b/toolbox/@STREAMobj/klargestconncomps.m
@@ -26,7 +26,7 @@ function S = klargestconncomps(S,k)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S  = STREAMobj(FD,A>1000);
 %     S2 = klargestconncomps(S,2);
 %     plot(S)

--- a/toolbox/@STREAMobj/networksegment.m
+++ b/toolbox/@STREAMobj/networksegment.m
@@ -47,7 +47,7 @@ function segment = networksegment(S,FD,DEM,A,mnratio)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     A  = flowacc(FD);
 %     S = STREAMobj(FD,'minarea',1000);
 %     segment = networksegment(S,FD,DEM,A,0.39);

--- a/toolbox/@STREAMobj/plot.m
+++ b/toolbox/@STREAMobj/plot.m
@@ -44,7 +44,7 @@ function h = plot(S,varargin)
 % Example
 %     
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     S  = STREAMobj(FD,'minarea',1000);
 %     plot(S)
 % 

--- a/toolbox/@STREAMobj/slopearea.m
+++ b/toolbox/@STREAMobj/slopearea.m
@@ -87,7 +87,7 @@ function OUT = slopearea(S,DEM,A,varargin)
 %     % This DEM is not well suited to show an application of slope area
 %     % plots. The DEM has various sinks located along streams resulting in
 %     % many zero gradients. 
-%     FD  = FLOWobj(DEM,'preprocess','c');
+%     FD  = FLOWobj(DEM);
 %     A   = flowacc(FD);
 %     S   = STREAMobj(FD,A>1000);     
 %     SA  = slopearea(S,DEM,A);

--- a/toolbox/@STREAMobj/streamproj.m
+++ b/toolbox/@STREAMobj/streamproj.m
@@ -71,7 +71,7 @@ function [newz,varargout] = streamproj(S,DEM,FA,varargin)
 % Examples
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     FA = flowacc(FD);
 %     DEMc = imposemin(FD,DEM,0.0001);
 %     S = STREAMobj(FD,'minarea',1000);

--- a/toolbox/@STREAMobj/union.m
+++ b/toolbox/@STREAMobj/union.m
@@ -34,7 +34,7 @@ function S = union(varargin)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     A  = flowacc(FD);
 %     S  = STREAMobj(FD,A>1000);
 %     CS = STREAMobj2cell(split(S));

--- a/toolbox/internal/getdivide.m
+++ b/toolbox/internal/getdivide.m
@@ -28,7 +28,7 @@ function OUT = getdivide(MS,IX,FD)
 % Example
 %
 %     DEM = GRIDobj('srtm_bigtujunga30m_utm11.tif');
-%     FD = FLOWobj(DEM,'preprocess','c');
+%     FD = FLOWobj(DEM);
 %     FA = flowacc(FD);
 %     ST = STREAMobj(FD,FA>1000);
 %     S = streamorder(FD,FA>1000);


### PR DESCRIPTION
All help sections were checked whether FLOWobj is called with the argument 'preprocess','c'. This returns an error in TT3 and thus all occurrences of this syntax have been updated to FD = FLOWobj(DEM);