### PR TITLE
Use windows-2022 for the Windows builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         matlab-version: [R2023b, latest]
     steps:
       - name: Checkout repository
@@ -24,7 +24,7 @@ jobs:
         uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v 3.0.1
         with:
           release: ${{ matrix.matlab-version }}
-          cache: ${{ matrix.os != 'windows-latest' }}
+          cache: ${{ matrix.os != 'windows-2022' }}
           products: >
             Mapping_Toolbox
             Image_Processing_Toolbox
@@ -46,7 +46,7 @@ jobs:
       - name: Verify snapshot data
         working-directory: tests/snapshots
         shell: bash
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-2022' }}
         run:
           shasum -c --status sha256sum.txt
       - name: Run checks and tests


### PR DESCRIPTION
GitHub Actions runners have switched to using VS 2026 on the
windows-latest image. I believe MATLAB's provided CMake, which we use
to compile the libtopotoolbox code, is limited to VS 2022.

This is not a long-term solution. We should probably try to use the
system CMake if it exists and only fall back to the MATLAB-provided
CMake if necessary (i.e. on a user's machine without a separate CMake
installation).