### PR TITLE
Attempt to use the system-provided CMake if it is available

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -6,7 +6,7 @@ project(
   LANGUAGES C
 )
 
-include(FindMatlab)
+find_package(Matlab)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.22)
 
 project(
   mxtopotoolbox
@@ -21,7 +21,8 @@ matlab_add_mex(
   MODULE
   SRC tt_has_topotoolbox.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -29,7 +30,8 @@ matlab_add_mex(
   MODULE
   SRC tt_fillsinks.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -37,7 +39,8 @@ matlab_add_mex(
   MODULE
   SRC tt_identifyflats.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -45,7 +48,8 @@ matlab_add_mex(
   MODULE
   SRC tt_gwdt_computecosts.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -53,7 +57,8 @@ matlab_add_mex(
   MODULE
   SRC tt_gwdt.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -61,7 +66,8 @@ matlab_add_mex(
   MODULE
   SRC tt_flow_routing_d8_carve.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -69,7 +75,8 @@ matlab_add_mex(
   MODULE
   SRC tt_lowerenv.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -77,7 +84,8 @@ matlab_add_mex(
   MODULE
   SRC tt_hillshade.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -85,7 +93,8 @@ matlab_add_mex(
   MODULE
   SRC tt_hillshade_fused.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES  
 )
 
 matlab_add_mex(
@@ -93,7 +102,8 @@ matlab_add_mex(
   MODULE
   SRC tt_graphflood.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES  
 )
 
 matlab_add_mex(
@@ -101,7 +111,8 @@ matlab_add_mex(
   MODULE
   SRC tt_gradient8.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES  
 )
 
 matlab_add_mex(
@@ -109,7 +120,8 @@ matlab_add_mex(
   MODULE
   SRC tt_excesstopography_fmm2d.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES  
 )
 
 matlab_add_mex(
@@ -117,7 +129,8 @@ matlab_add_mex(
   MODULE
   SRC tt_excesstopography_fmm3d.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES  
 )
 
 matlab_add_mex(
@@ -125,7 +138,8 @@ matlab_add_mex(
   MODULE
   SRC tt_excesstopography_fsm2d.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES  
 )
 
 matlab_add_mex(
@@ -133,7 +147,8 @@ matlab_add_mex(
   MODULE
   SRC tt_streamquad_trapz_f32.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -141,7 +156,8 @@ matlab_add_mex(
   MODULE
   SRC tt_streamquad_trapz_f64.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -149,7 +165,8 @@ matlab_add_mex(
   MODULE
   SRC tt_traverse_down_f32_add_mul.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 matlab_add_mex(
@@ -157,7 +174,8 @@ matlab_add_mex(
   MODULE
   SRC tt_traverse_down_f64_add_mul.c
   R2018a
-  LINK_TO topotoolbox
+  LINK_TO topotoolbox Matlab::mex Matlab::mx
+  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
 )
 
 install(

--- a/buildfile.m
+++ b/buildfile.m
@@ -65,20 +65,31 @@ end
 end
 
 function compileTask(~)
-    %% Path to MATLAB provided cmake
-    cmake = fullfile(matlabroot, 'bin', computer('arch'),'cmake','bin','cmake');
-    % The windows version has a blank in the program folder name
-    % (C:/Program Files), thus we use additional double quotes.
-    cmake = ['"' cmake '"'];
+    % Check if there is a system-provided cmake
+    if system("cmake --version", "LD_LIBRARY_PATH", "") == 0
+        cmake = "cmake";
+        ld_library_path = "";
+    else
+        %% Path to MATLAB provided cmake
+        cmake = fullfile(matlabroot, 'bin', computer('arch'),'cmake','bin','cmake');
+        % The windows version has a blank in the program folder name
+        % (C:/Program Files), thus we use additional double quotes.
+        cmake = ['"' cmake '"'];
+        ld_library_path = getenv("LD_LIBRARY_PATH");
+    end
 
-    if system(strcat(cmake," --version")) ~= 0
+    if system(strcat(cmake," --version"), "LD_LIBRARY_PATH", ld_library_path) ~= 0
         disp("CMake is not provided by MATLAB. MATLAB Coder must be installed.");
         return;
     end
     %% Run cmake
-    system(strcat(cmake," -S bindings/ -B build -DCMAKE_BUILD_TYPE=Release"));
-    system(strcat(cmake," --build build --config Release"));
-    system(strcat(cmake," --install build --prefix toolbox/internal/mex --component Runtime"));
+    system(strcat(cmake," -S bindings/ -B build -DCMAKE_BUILD_TYPE=Release"), ...
+        "LD_LIBRARY_PATH", ld_library_path);
+    system(strcat(cmake," --build build --config Release"), ...
+        "LD_LIBRARY_PATH", ld_library_path);
+    system(strcat(cmake, ...
+        " --install build --prefix toolbox/internal/mex --component Runtime"), ...
+        "LD_LIBRARY_PATH", ld_library_path);
 end
 
 function benchmarkTask(~)


### PR DESCRIPTION
We historically have used the CMake provided by MATLAB Coder to
compile libtopotoolbox. This works well because users don't need to
install CMake to get libtopotoolbox compiled on their system. #176
revealed that the CMake provided with MATLAB is rather old and can't
support VS 2026, which is now installed on the windows-latest
GitHub-provided Actions runners.

This change checks to see if we can call the system cmake directly, in
which case we use that. Otherwise, we fallback on the existing system,
which is to try the MATLAB-provided cmake and then to fail.

MATLAB sets the LD_LIBRARY_PATH variable on UNIX systems for its own
purposes, but this messed up my system installation of cmake, because
it finds a MATLAB-provided libc. To avoid this, I clear
LD_LIBRARY_PATH when calling cmake. This might fail if a user needs to
set LD_LIBRARY_PATH normally to use cmake. In that case, though, we
fall back on the MATLAB-provided cmake. I am not sure how this will
behave on Windows.