### PR TITLE
Changes to GRIDobj2geotable and geotable2mapstruct

### DIFF
--- a/toolbox/@GRIDobj/GRIDobj2geotable.m
+++ b/toolbox/@GRIDobj/GRIDobj2geotable.m
@@ -27,10 +27,14 @@ function [GT,x,y] = GRIDobj2geotable(DB,options)
 %     'holes'        {true} or false
 %     'parallel'     {true} or false. If true, function is run in parallel.
 %                    Testing is required to check performance differences.
+%     'nan2zero'     {true} or false. If true, nan-values in DB are
+%                    converted to zero. No polygons will be returned for
+%                    nan-regions.
 %
 % Output arguments
 %
-%     GT      geotable
+%     GT      geotable. The table contains the four variables Shape, 
+%             Geometry, ID and gridvalue.
 %     x,y     nan-punctuated coordinate vectors of the polygon outlines
 %     
 % Example 1
@@ -57,19 +61,24 @@ function [GT,x,y] = GRIDobj2geotable(DB,options)
 %           GRIDobj/cropbyregion
 % 
 % Author: Wolfgang Schwanghart (schwangh[at]uni-potsdam.de)
-% Date: 7. November, 2025 
+% Date: 8. July, 2026 
 
 arguments (Input)
     DB   GRIDobj
-    options.simplify = false
-    options.tol      = 0
-    options.conn      = 8;
-    options.holes    = true;
-    options.parallel = false;
+    options.simplify (1,1) = false
+    options.tol      (1,1) = 0
+    options.conn     (1,1) {mustBeMember(options.conn,[4 8])} = 8;
+    options.nan2zero (1,1) = true
+    options.holes    (1,1) = true;
+    options.parallel (1,1) = false;
 end
 
 holes = options.holes;
 conn  = options.conn;
+
+if options.nan2zero 
+    DB.Z(isnan(DB.Z)) = 0;
+end
 
 if isempty(DB.georef)
     error('DB.georef must contain a reference object.')
@@ -118,9 +127,11 @@ end
 
 validIDs = find(isvalid);
 validIDs = validIDs(:);
-ID = num2cell(validIDs);
+gridvalue = num2cell(validIDs);
+ID   = num2cell(1:numel(gridvalue))';
 Geom = repmat({'Geometry'},nregions,1);
-GT = cell2table([s Geom ID],"VariableNames",["Shape" "Geometry" "ID"]);
+GT = cell2table([s Geom ID gridvalue],...
+    "VariableNames",["Shape" "Geometry" "ID" "gridvalue"]);
 
 if isgeo
     GT.Shape.GeographicCRS = CRS;

--- a/toolbox/@PPS/mnoptimkp.m
+++ b/toolbox/@PPS/mnoptimkp.m
@@ -251,6 +251,7 @@ switch lower(options.method)
         results.mdl = mdl;
         results.int = int;
         results.chimax = locmax;
+        results.a0  = options.a0;
         
         if ~isempty(options.t)
             tini = options.t; % onset of incision

--- a/toolbox/GIStools/geotable2mapstruct.m
+++ b/toolbox/GIStools/geotable2mapstruct.m
@@ -1,4 +1,4 @@
-function MS = geotable2mapstruct(GT)
+function MS = geotable2mapstruct(GT,options)
 
 %GEOTABLE2MAPSTRUCT Convert a geotable to a mapping structure
 %
@@ -14,6 +14,18 @@ function MS = geotable2mapstruct(GT)
 %
 %     GT    geotable
 %
+%     Parameter name/value pairs
+%
+%     'xycolvec'   {false} or true. If true, x- and y-coordinates are 
+%                  stored as column vectors. By default, they are row
+%                  vectors.
+%     'appendnan'  {false} or true. If true, a nan is appended at the end 
+%                  of the x and y coordinate vectors.
+%
+% Output arguments
+%
+%     MS    structure array
+%
 % See also: mapstruct2geotable, polygon2GRIDobj,
 %           STREAMobj/STREAMobj2geotable, STREAMobj/STREAMobj2mapstruct
 %
@@ -22,6 +34,8 @@ function MS = geotable2mapstruct(GT)
 
 arguments
     GT {mustBeGeotable}
+    options.xycolvec (1,1) = false
+    options.appendnan   (1,1) = false
 end
 
 [~,isproj] = parseCRS(GT);
@@ -31,6 +45,16 @@ if ~isproj
 else
     MS = geotable2table(GT,["X" "Y"]);
 
+end
+
+if options.appendnan
+    MS.X = cellfun(@(x) [x nan],MS.X,'UniformOutput',false);
+    MS.Y = cellfun(@(x) [x nan],MS.Y,'UniformOutput',false);
+end
+
+if options.xycolvec
+    MS.X = cellfun(@(x) x(:),MS.X,'UniformOutput',false);
+    MS.Y = cellfun(@(x) x(:),MS.Y,'UniformOutput',false);
 end
 
 geomType = GT.Shape.Geometry;

--- a/toolbox/graphics/plotboxpos.m
+++ b/toolbox/graphics/plotboxpos.m
@@ -1,0 +1,120 @@
+function pos = plotboxpos(h)
+%PLOTBOXPOS Returns the position of the plotted axis region
+%
+% pos = plotboxpos(h)
+%
+% This function returns the position of the plotted region of an axis,
+% which may differ from the actual axis position, depending on the axis
+% limits, data aspect ratio, and plot box aspect ratio.  The position is
+% returned in the same units as the those used to define the axis itself.
+% This function can only be used for a 2D plot.  
+%
+% Input variables:
+%
+%   h:      axis handle of a 2D axis (if ommitted, current axis is used).
+%
+% Output variables:
+%
+%   pos:    four-element position vector, in same units as h
+% Copyright 2010 Kelly Kearney
+% Check input
+if nargin < 1
+    h = gca;
+end
+if ~ishandle(h) || ~strcmp(get(h,'type'), 'axes')
+    error('Input must be an axis handle');
+end
+% Get position of axis in pixels
+currunit = get(h, 'units');
+axisPos  = getpixelposition(h);
+% Calculate box position based axis limits and aspect ratios
+darismanual  = strcmpi(get(h, 'DataAspectRatioMode'),    'manual');
+pbarismanual = strcmpi(get(h, 'PlotBoxAspectRatioMode'), 'manual');
+if ~darismanual && ~pbarismanual
+    
+    pos = axisPos;
+    
+else
+    xlim = get(h, 'XLim');
+    ylim = get(h, 'YLim');
+    
+    % Deal with axis limits auto-set via Inf/-Inf use
+    
+    if any(isinf([xlim ylim]))
+        hc = get(h, 'Children');
+        hc(~arrayfun( @(h) isprop(h, 'XData' ) & isprop(h, 'YData' ), hc)) = [];
+        xdata = get(hc, 'XData');
+        if iscell(xdata)
+            xdata = cellfun(@(x) x(:), xdata, 'uni', 0);
+            xdata = cat(1, xdata{:});
+        end
+        ydata = get(hc, 'YData');
+        if iscell(ydata)
+            ydata = cellfun(@(x) x(:), ydata, 'uni', 0);
+            ydata = cat(1, ydata{:});
+        end
+        isplotted = ~isinf(xdata) & ~isnan(xdata) & ...
+                    ~isinf(ydata) & ~isnan(ydata);
+        xdata = xdata(isplotted);
+        ydata = ydata(isplotted);
+        if isempty(xdata)
+            xdata = [0 1];
+        end
+        if isempty(ydata)
+            ydata = [0 1];
+        end
+        if isinf(xlim(1))
+            xlim(1) = min(xdata);
+        end
+        if isinf(xlim(2))
+            xlim(2) = max(xdata);
+        end
+        if isinf(ylim(1))
+            ylim(1) = min(ydata);
+        end
+        if isinf(ylim(2))
+            ylim(2) = max(ydata);
+        end
+    end
+    dx = diff(xlim);
+    dy = diff(ylim);
+    dar = get(h, 'DataAspectRatio');
+    pbar = get(h, 'PlotBoxAspectRatio');
+    limDarRatio = (dx/dar(1))/(dy/dar(2));
+    pbarRatio = pbar(1)/pbar(2);
+    axisRatio = axisPos(3)/axisPos(4);
+    if darismanual
+        if limDarRatio > axisRatio
+            pos(1) = axisPos(1);
+            pos(3) = axisPos(3);
+            pos(4) = axisPos(3)/limDarRatio;
+            pos(2) = (axisPos(4) - pos(4))/2 + axisPos(2);
+        else
+            pos(2) = axisPos(2);
+            pos(4) = axisPos(4);
+            pos(3) = axisPos(4) * limDarRatio;
+            pos(1) = (axisPos(3) - pos(3))/2 + axisPos(1);
+        end
+    elseif pbarismanual
+        if pbarRatio > axisRatio
+            pos(1) = axisPos(1);
+            pos(3) = axisPos(3);
+            pos(4) = axisPos(3)/pbarRatio;
+            pos(2) = (axisPos(4) - pos(4))/2 + axisPos(2);
+        else
+            pos(2) = axisPos(2);
+            pos(4) = axisPos(4);
+            pos(3) = axisPos(4) * pbarRatio;
+            pos(1) = (axisPos(3) - pos(3))/2 + axisPos(1);
+        end
+    end
+end
+% Convert plot box position to the units used by the axis
+hparent = get(h, 'parent');
+hfig = ancestor(hparent, 'figure'); % in case in panel or similar
+currax = get(hfig, 'currentaxes');
+temp = axes('Units', 'Pixels', 'Position', pos, 'Visible', 'off', 'parent', hparent);
+set(temp, 'Units', currunit);
+pos = get(temp, 'position');
+delete(temp);
+set(hfig, 'currentaxes', currax);


### PR DESCRIPTION
This commit includes changes to GRIDobj2geotable (additional parsing, return of an additional field called gridvalue) and geotable2mapstruct (additional option to return column vectors of coordinates in the mapping structure as well as an option to append nans at the end of the coordinate vectors). Moreover, I have added plotboxpos, a function that makes it easy to align axes in a figure. The output structure array of mnoptimkp now includes the reference area.