### PR TITLE
Fix links to shared libraries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,11 +86,41 @@ jobs:
         with:
           name: toolbox-${{ matrix.os }}-${{ matrix.mex }}
           path: release/TopoToolbox_*.mltbx
+  test:
+    name: Download, install and test the toolbox
+    runs-on: ${{ matrix.os }}
+    needs: [package]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-26, windows-latest]
+        matlab-version: [R2023b, R2024a, R2024b, R2025a, R2025b, R2026a]
+    steps:
+      - name: Checkout repository
+        uses: TopoToolbox/actions/checkout@main
+      - name: Setup MATLAB
+        uses: TopoToolbox/actions/setup-matlab@main
+        with:
+          release: ${{ matrix.matlab-version }}
+          cache: ${{ matrix.os != 'windows-latest' }}
+          products: >-
+            Mapping_Toolbox
+            Image_Processing_Toolbox
+            MATLAB_Coder
+      - name: Download artifacts
+        with:
+          name: toolbox-${{ matrix.os }}
+          path: release/
+        uses: TopoToolbox/actions/download-artifact@main
+      - name: Run toolbox build step
+        uses: TopoToolbox/actions/run-build@main
+        with:
+          tasks: testToolbox        
   release:
     if: github.repository == 'TopoToolbox/topotoolbox3'
     name: Update release
     runs-on: ubuntu-latest
-    needs: [package]
+    needs: [test]
     permissions:
       contents: write
     env:

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -6,6 +6,7 @@ project(
   LANGUAGES C
 )
 
+set(MATLAB_FIND_DEBUG TRUE)
 find_package(Matlab)
 
 include(FetchContent)
@@ -45,9 +46,25 @@ foreach(TT_MEX_TARGET IN LISTS TT_MEX_TARGETS)
     MODULE
     SRC ${TT_MEX_TARGET}.c
     R2018a
-    LINK_TO topotoolbox Matlab::mex Matlab::mx
+    LINK_TO topotoolbox
     NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
   )
+  # NOTE(wkearn): We have to link the MATLAB libraries ourselves for
+  # now.
+  #
+  # 1. If we implicitly link to the MATLAB libraries, macos looks in
+  #    the wrong place for the libMatlabEngine.dylib and fails to load
+  #    it. Since we don't use the MATLAB C++ Engine, we can get away
+  #    with
+  #
+  # 2. If we instead use the Matlab::mex and Matlab::mx targets, Linux
+  #    will hardcode the paths to the shared libraries. This will fail
+  #    when moved to a different machine.
+  #
+  # The solution is to use the Matlab_MEX_LIBRARY and
+  # Matlab_MX_LIBRARY variables provided by FindMatlab. This is what
+  # matlab_add_mex does itself and seems to work.
+  target_link_libraries(${TT_MEX_TARGET} ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY})
   if(APPLE)
     target_link_options(${TT_MEX_TARGET} PRIVATE -ld_classic)
   endif()

--- a/buildfile.m
+++ b/buildfile.m
@@ -151,3 +151,13 @@ function docTask(~)
 
     publishtthelp2html;
 end
+
+function testToolboxTask(~)
+
+file = fullfile("release",['TopoToolbox_' computer('arch') '.mltbx']);
+
+matlab.addons.toolbox.installToolbox(file);
+
+haslibtopotoolbox
+
+end


### PR DESCRIPTION
Resolves #190

To link the MATLAB libraries correctly on Linux, macos and Windows using CMake, we need to call target_link_libraries ourselves with the Matlab_MEX_LIBRARY and Matlab_MX_LIBRARY. Using the Matlab::mex and Matlab::mx targets causes Linux to hardcode the paths of the shared libraries, which will break when using different MATLAB versions. Using the implicit linking works on Linux, but fails because macos looks in the wrong places for the MATLAB C++ engine, which we don't need anyway (see #177).

To make sure that we don't run into these kinds of problems, I have added a test step to the release process. The toolboxes compiled on MATLAB latest will be downloaded and tested on our supported versions. Any failures will stop the release from happening so we don't end up with a bad release.