### PR TITLE
Set MATLAB_ADDITIONAL_VERSIONS

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -6,6 +6,15 @@ project(
   LANGUAGES C
 )
 
+set(MATLAB_ADDITIONAL_VERSIONS
+  "R2026a=26.1"
+  "R2025b=25.2"
+  "R2025a=25.1"
+  "R2024b=24.2"
+  "R2024a=24.1"
+  "R2023b=23.2"
+)
+
 set(MATLAB_FIND_DEBUG TRUE)
 find_package(Matlab)
 


### PR DESCRIPTION
This is necessary for CMake to find newer versions of MATLAB successfully on some platforms (macOS, in particular). Newer versions of CMake have these MATLAB versions predefined, but the CMake that comes with MATLAB Coder is rather old (3.25), so these are not predefined and CMake will fail to find MATLAB.